### PR TITLE
Simplify incoming core event creation

### DIFF
--- a/publisher/drivers/checkov.py
+++ b/publisher/drivers/checkov.py
@@ -18,13 +18,13 @@ class Checkov(EventSource):
                 events.append(GuardrailPassed(
                     aggregate_id = repo_name + "." + result["resource"],
                     guardrail_id = result["check_id"],
-                    time = current_time,
+                    timestamp = current_time,
                 ))
             for result in file_data["results"]["failed_checks"]:
                 events.append(GuardrailActivated(
                     aggregate_id = repo_name + "." + result["resource"],
                     guardrail_id = result["check_id"],
-                    time = current_time,
+                    timestamp = current_time,
                 ))
             return tuple(events)
         return Exception(f"Unable to read Checkov results from file")

--- a/publisher/drivers/open_policy_agent.py
+++ b/publisher/drivers/open_policy_agent.py
@@ -19,13 +19,13 @@ class OpenPolicyAgent(EventSource):
                     events.append(GuardrailPassed(
                         aggregate_id = repo_name + "." + result["input"]["metadata"]["namespace"] + "."  + result["input"]["metadata"]["name"],
                         guardrail_id = result["query"],
-                        time = current_time,
+                        timestamp = current_time,
                     ))
                 else:
                     events.append(GuardrailActivated(
                         aggregate_id = repo_name + "." + result["input"]["metadata"]["namespace"] + "." + result["input"]["metadata"]["name"],
                         guardrail_id = result["query"],
-                        time = current_time,
+                        timestamp = current_time,
                     ))
             return tuple(events)
         return Exception(f"Unable to read Open Policy Agent results from file")

--- a/publisher/entities/guardrail.py
+++ b/publisher/entities/guardrail.py
@@ -7,12 +7,12 @@ from publisher.entities.base import BaseEvent
 @dataclass
 class GuardrailActivated(BaseEvent):
     guardrail_id: str
-    time: int
+    timestamp: int
     event_type: Literal["guardrail_activated"] = "guardrail_activated"
 
 
 @dataclass
 class GuardrailPassed(BaseEvent):
     guardrail_id: str
-    time: int
+    timestamp: int
     event_type: Literal["guardrail_passed"] = "guardrail_passed"

--- a/src/adapters/controller.py
+++ b/src/adapters/controller.py
@@ -1,19 +1,43 @@
-from typing import Any, List, Tuple, Union
+from typing import Dict, List, Tuple, Union
+from uuid import uuid4
 
-from src.entities.events import Event
+from src.entities.events import Event, EVENT_CLASSES
 from src.entities.metrics import Metric
 from src.usecases.event_functions import EVENT_FUNCTIONS
 
+def _convert_payload_to_event(
+    payload: Dict, aggregate_version: int
+) -> Event:
+    try:
+        event_type = payload["event_type"]
+        aggregate_id = payload["aggregate_id"]
+        event_payload = payload.copy()
+        for key in ["event_type", "aggregate_id"]:
+            event_payload.pop(key, None)
+        event_class, payload_class = EVENT_CLASSES[event_type]
+        return event_class(
+            aggregate_id=aggregate_id,
+            aggregate_version=aggregate_version + 1,
+            event_id=str(uuid4()),
+            payload=payload_class(**event_payload)
+        )
+    except Exception as err:
+        return err
 
 def handle_event(
-    payload: Any, aggregate_events: List[Event]
+    payload: Dict, aggregate_events: List[Event]
 ) -> Union[Exception, Tuple[Event, List[Metric]]]:
     if "event_type" in payload:
-        if payload["event_type"] in EVENT_FUNCTIONS:
-            event, metrics = EVENT_FUNCTIONS[payload["event_type"]](
-                payload, aggregate_events
-            )
-            return (event, metrics)
+        event_type = payload["event_type"]
+        if event_type in EVENT_CLASSES:
+            event = _convert_payload_to_event(payload, len(aggregate_events))
+            if event_type in EVENT_FUNCTIONS:
+                event, metrics = EVENT_FUNCTIONS[event_type](
+                    event, aggregate_events
+                )
+                return (event, metrics)
+            else:
+                return Exception(f"No event type function defined: {event_type}")
         else:
-            return Exception(f"Unknown event type {payload['event_type']}")
+            return Exception(f"Unknown event type {event_type}")
     return Exception("Malformed event with no event_type")

--- a/src/drivers/timestream_metric_sink.py
+++ b/src/drivers/timestream_metric_sink.py
@@ -18,7 +18,6 @@ class TimeStreamMetricSink(MetricSink):
         self.timestream_client = boto3.client("timestream-write")
 
     def store_metrics(self, metrics: List[Metric]) -> Optional[Exception]:
-        logger.msg(f"Writing records for metrics {metrics}")
         current_time = round(time.time() * 1000)
         records = []
         for metric in metrics:
@@ -48,9 +47,5 @@ class TimeStreamMetricSink(MetricSink):
                     Records=records,
                     CommonAttributes={},
                 )
-                logger.msg(
-                    f"WriteRecords Status: {result['ResponseMetadata']['HTTPStatusCode']}"
-                )
         except Exception as err:
-            logger.error(f"Error: {err}")
             return err

--- a/src/entities/accounts.py
+++ b/src/entities/accounts.py
@@ -13,7 +13,7 @@ class AccountRequested(BaseEvent):
     aggregate_type = "Account"
     event_version = 1
     payload: AccountRequestedPayload
-    event_type = "account_requested"
+    event_type: Literal["account_requested"] = "account_requested"
 
 
 class AccountCreatedPayload(BaseModel):

--- a/src/entities/patch.py
+++ b/src/entities/patch.py
@@ -7,6 +7,7 @@ from src.entities.base import BaseEvent, BaseMetric
 
 # Events
 class PatchRunSummaryPayload(BaseModel):
+    timestamp: float
     failed_instances: str
     successful_instances: str
 

--- a/src/usecases/accounts.py
+++ b/src/usecases/accounts.py
@@ -1,41 +1,16 @@
-from typing import List, Dict, Tuple, Union
-from uuid import uuid4
+from typing import List, Tuple
 
 from src.entities.accounts import (
     AccountCreated,
-    AccountCreatedPayload,
     AccountLeadTime,
     AccountRequested,
-    AccountRequestedPayload,
 )
 from src.entities.events import Event
 
 
-def _convert_payload_to_event(
-    event: Dict, aggregate_version: int
-) -> Union[AccountCreated, AccountRequested]:
-    if event["event_type"] == "account_requested":
-        return AccountRequested(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=AccountRequestedPayload(timestamp=int(event["time"])),
-        )
-    elif event["event_type"] == "account_created":
-        return AccountCreated(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=AccountCreatedPayload(timestamp=int(event["time"])),
-        )
-
-
 def handle_account_created(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[AccountCreated, List[AccountLeadTime]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     if aggregate_events:
         return (
             event,
@@ -52,7 +27,6 @@ def handle_account_created(
 
 
 def handle_account_requested(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[AccountRequested, List]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (event, [])

--- a/src/usecases/compliance.py
+++ b/src/usecases/compliance.py
@@ -1,55 +1,23 @@
-from typing import List, Dict, Union, Tuple
-from uuid import uuid4
+from typing import List, Tuple
 
 from src.entities.compliance import (
     ResourceComplianceExtraDimensions,
     ResourceComplianceLeadTime,
     ResourceFoundCompliant,
-    ResourceFoundCompliantPayload,
     ResourceFoundNonCompliant,
-    ResourceFoundNonCompliantPayload,
 )
 from src.entities.events import Event
 
 
-def _convert_payload_to_event(
-    event: Dict, aggregate_version: int
-) -> Union[ResourceFoundCompliant, ResourceFoundNonCompliant]:
-    if event["event_type"] == "resource_found_non_compliant":
-        return ResourceFoundNonCompliant(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=ResourceFoundNonCompliantPayload(
-                container_id=event["container_id"],
-                timestamp=int(event["time"]),
-            ),
-        )
-    elif event["event_type"] == "resource_found_compliant":
-        return ResourceFoundCompliant(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=ResourceFoundCompliantPayload(
-                container_id=event["container_id"],
-                timestamp=int(event["time"]),
-            ),
-        )
-
-
 def handle_resource_found_non_compliant(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[ResourceFoundNonCompliant, List]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (event, [])
 
 
 def handle_resource_found_compliant(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[ResourceFoundCompliant, List[ResourceComplianceLeadTime]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     last_compliant_event = 0
     for i, aggregate_event in enumerate(aggregate_events):
         if isinstance(aggregate_event, ResourceFoundCompliant):

--- a/src/usecases/guardrail.py
+++ b/src/usecases/guardrail.py
@@ -5,42 +5,16 @@ from src.entities.events import Event
 from src.entities.guardrail import (
     GuardrailActivated,
     GuardrailActivationCount,
-    GuardrailActivatedPayload,
     GuardrailExtraDimensions,
     GuardrailLeadTime,
     GuardrailMaxActivation,
     GuardrailPassed,
-    GuardrailPassedPayload,
 )
 
 
-def _convert_payload_to_event(
-    event: Dict, aggregate_version: int
-) -> Union[GuardrailActivated, GuardrailPassed]:
-    if event["event_type"] == "guardrail_passed":
-        return GuardrailPassed(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            payload=GuardrailPassedPayload(
-                guardrail_id=event["guardrail_id"], timestamp=int(event["time"])
-            ),
-        )
-    elif event["event_type"] == "guardrail_activated":
-        return GuardrailActivated(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            payload=GuardrailActivatedPayload(
-                guardrail_id=event["guardrail_id"], timestamp=int(event["time"])
-            ),
-        )
-
-
 def handle_guardrail_activated(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[GuardrailActivated, List[GuardrailActivationCount]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     guardrail_activation_count = 1
     for aggregate_event in aggregate_events:
         if isinstance(aggregate_event, GuardrailActivated) and aggregate_event.payload.guardrail_id == event.payload.guardrail_id:
@@ -61,9 +35,8 @@ def handle_guardrail_activated(
 
 
 def handle_guardrail_passed(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[GuardrailPassed, List[Union[GuardrailLeadTime, GuardrailMaxActivation]]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     last_compliant_event = 0
     activations_since_last_pass = 0
     for i, aggregate_event in enumerate(aggregate_events):

--- a/src/usecases/identity.py
+++ b/src/usecases/identity.py
@@ -1,51 +1,21 @@
-from typing import Dict, List, Tuple, Union
-from uuid import uuid4
+from typing import List, Tuple, Union
+
 from src.entities.events import Event
 from src.entities.identity import (
-    IdentityCreated,
-    IdentityCreatedPayload,
     IdentityLeadTime,
     IdentityRequested,
-    IdentityRequestedPayload,
 )
 
 
-def _convert_payload_to_event(
-    event: Dict, aggregate_version: int
-) -> Union[IdentityRequested, IdentityCreated]:
-    if event["event_type"] == "identity_requested":
-        return IdentityRequested(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=IdentityRequestedPayload(
-                timestamp=int(event["time"]), account_id=event["account_id"]
-            ),
-        )
-    elif event["event_type"] == "identity_created":
-        return IdentityCreated(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=IdentityCreatedPayload(
-                timestamp=int(event["time"]), account_id=event["account_id"]
-            ),
-        )
-
-
 def handle_identity_requested(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[IdentityRequested, List]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (event, [])
 
 
 def handle_identity_created(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[IdentityRequested, List]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (
         event,
         [

--- a/src/usecases/patch.py
+++ b/src/usecases/patch.py
@@ -1,30 +1,15 @@
-from typing import Dict, List, Tuple
-from uuid import uuid4
+from typing import List, Tuple
 
 from src.entities.events import Event
 from src.entities.patch import (
     PatchRunSummary,
-    PatchRunSummaryPayload,
     PatchCompliancePercentage,
 )
 
 
-def _convert_payload_to_event(event: Dict, aggregate_version: int) -> PatchRunSummary:
-    return PatchRunSummary(
-        aggregate_id=event["aggregate_id"],
-        aggregate_version=aggregate_version + 1,
-        event_id=str(uuid4()),
-        payload=PatchRunSummaryPayload(
-            failed_instances=event["failed_instances"],
-            successful_instances=event["successful_instances"],
-        ),
-    )
-
-
 def handle_patch_summary(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[PatchRunSummary, List[PatchCompliancePercentage]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (
         event,
         [

--- a/src/usecases/projects.py
+++ b/src/usecases/projects.py
@@ -14,46 +14,16 @@ from src.entities.projects import (
 )
 
 
-def _convert_payload_to_event(
-    event: Dict, aggregate_version: int
-) -> Union[ProjectAssigned, ProjectCreated, ProjectRequested]:
-    if event["event_type"] == "project_assigned":
-        return ProjectAssigned(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=ProjectAssignedPayload(timestamp=int(event["time"])),
-        )
-    elif event["event_type"] == "project_created":
-        return ProjectCreated(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=ProjectCreatedPayload(timestamp=int(event["time"])),
-        )
-    elif event["event_type"] == "project_requested":
-        return ProjectRequested(
-            aggregate_id=event["aggregate_id"],
-            aggregate_version=aggregate_version + 1,
-            event_id=str(uuid4()),
-            event_version=1,
-            payload=ProjectRequestedPayload(timestamp=int(event["time"])),
-        )
-
 
 def handle_project_requested(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[ProjectRequested, List]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     return (event, [])
 
 
 def handle_project_assigned(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[ProjectAssigned, List[ProjectAssignedLeadTime]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     if aggregate_events:
         return (
             event,
@@ -70,9 +40,8 @@ def handle_project_assigned(
 
 
 def handle_project_created(
-    event: Dict, aggregate_events: List[Event]
+    event: Event, aggregate_events: List[Event]
 ) -> Tuple[ProjectCreated, List[ProjectLeadTime]]:
-    event = _convert_payload_to_event(event, len(aggregate_events))
     if aggregate_events:
         return (
             event,

--- a/tests/features/steps/account_steps.py
+++ b/tests/features/steps/account_steps.py
@@ -24,7 +24,7 @@ def request_account(context):
                     {
                         "event_type": "account_requested",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",
@@ -48,7 +48,7 @@ def created_account(context):
                     {
                         "event_type": "account_created",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",

--- a/tests/features/steps/compliance_steps.py
+++ b/tests/features/steps/compliance_steps.py
@@ -25,7 +25,7 @@ def found_non_compliant(context):
                         "event_type": "resource_found_non_compliant",
                         "container_id": "123456789012",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",
@@ -50,7 +50,7 @@ def found_compliant(context):
                         "event_type": "resource_found_compliant",
                         "container_id": "123456789012",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",

--- a/tests/features/steps/guardrail_steps.py
+++ b/tests/features/steps/guardrail_steps.py
@@ -24,7 +24,7 @@ def guardrail_activated(context):
                         "event_type": "guardrail_activated",
                         "guardrail_id": f"{context.guardrail_id}",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",
@@ -57,7 +57,7 @@ def guardrail_passes(context):
                         "event_type": "guardrail_passed",
                         "guardrail_id": f"{context.guardrail_id}",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",

--- a/tests/features/steps/identity_steps.py
+++ b/tests/features/steps/identity_steps.py
@@ -25,7 +25,7 @@ def request_identity(context):
                     {
                         "event_type": "identity_requested",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                         "account_id": f"{context.account_id}",
                     }
                 ),
@@ -50,7 +50,7 @@ def created_identity(context):
                     {
                         "event_type": "identity_created",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                         "account_id": f"{context.account_id}",
                     }
                 ),

--- a/tests/features/steps/patch_steps.py
+++ b/tests/features/steps/patch_steps.py
@@ -24,7 +24,7 @@ def received_summary(context):
                     {
                         "event_type": "patch_run_summary",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                         "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
                         "successful_instances": "i-peoritdsfl",
                     }

--- a/tests/features/steps/project_steps.py
+++ b/tests/features/steps/project_steps.py
@@ -25,7 +25,7 @@ def request_project(context):
                     {
                         "event_type": "project_requested",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",
@@ -47,7 +47,7 @@ def create_project(context):
                     {
                         "event_type": "project_created",
                         "aggregate_id": f"{context.aggregate_id}",
-                        "time": f"{requested_time}",
+                        "timestamp": f"{requested_time}",
                     }
                 ),
                 "EventBusName": "main_lambda_bus_cdktf",

--- a/tests/publisher/drivers/test_event_bridge.py
+++ b/tests/publisher/drivers/test_event_bridge.py
@@ -18,12 +18,12 @@ EVENTS = [
     GuardrailActivated(
         aggregate_id = AGGREGATE_ID,
         guardrail_id = ALTERNATE_ID,
-        time = CURRENT_TIME,
+        timestamp = CURRENT_TIME,
     ),
     GuardrailPassed(
         aggregate_id = AGGREGATE_ID,
         guardrail_id = ALTERNATE_ID,
-        time = CURRENT_TIME,
+        timestamp = CURRENT_TIME,
     ),
 ]
 
@@ -31,7 +31,7 @@ DOZEN_EVENTS = [
     GuardrailActivated(
         aggregate_id = AGGREGATE_ID,
         guardrail_id = ALTERNATE_ID,
-        time = CURRENT_TIME,
+        timestamp = CURRENT_TIME,
     ) for i in range(12)
 ]
 

--- a/tests/src/adapters/test_controller.py
+++ b/tests/src/adapters/test_controller.py
@@ -31,7 +31,7 @@ CURRENT_TIME = int(time())
 patch_run_summary_event = {
     "event_type": "patch_run_summary",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
     "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
     "successful_instances": "i-peoritdsfl",
 }
@@ -50,58 +50,58 @@ guardrail_activated_event = {
     "event_type": "guardrail_activated",
     "aggregate_id": guardrail_activated_aggregate_event.aggregate_id,
     "guardrail_id": guardrail_activated_aggregate_event.payload.guardrail_id,
-    "time": CURRENT_TIME,
+    "timestamp": CURRENT_TIME,
 }
 
 guardrail_passed_event = {
     "event_type": "guardrail_passed",
     "aggregate_id": guardrail_activated_aggregate_event.aggregate_id,
     "guardrail_id": guardrail_activated_aggregate_event.payload.guardrail_id,
-    "time": int(guardrail_activated_aggregate_event.payload.timestamp + 10),
+    "timestamp": int(guardrail_activated_aggregate_event.payload.timestamp + 10),
 }
 
 resource_found_non_compliant = {
     "event_type": "resource_found_non_compliant",
     "container_id": f"{ALTERNATE_ID}",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 resource_found_compliant = {
     "event_type": "resource_found_compliant",
     "container_id": f"{ALTERNATE_ID}",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 account_requested = {
     "event_type": "account_requested",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 account_created = {
     "event_type": "account_created",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 project_requested = {
     "event_type": "project_requested",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 project_assigned = {
     "event_type": "project_assigned",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 project_created = {
     "event_type": "project_created",
     "aggregate_id": f"{AGGREGATE_ID}",
-    "time": f"{CURRENT_TIME}",
+    "timestamp": f"{CURRENT_TIME}",
 }
 
 

--- a/tests/src/drivers/test_dynamo_event_sink.py
+++ b/tests/src/drivers/test_dynamo_event_sink.py
@@ -134,6 +134,7 @@ def test_retrieves_patch_events_from_dynamodb():
         aggregate_version=1,
         event_id=uuid4(),
         payload=PatchRunSummaryPayload(
+            timestamp=int(round(datetime.utcnow().timestamp())),
             successful_instances="i-adslkjfds,i-89dsfkjdkfj",
             failed_instances="i-peoritdsfl",
         ),

--- a/tests/src/entrypoints/test_lamdarun.py
+++ b/tests/src/entrypoints/test_lamdarun.py
@@ -18,7 +18,7 @@ def test_lambda_handles_basic_event():
             "detail": {
                 "event_type": "account_requested",
                 "aggregate_id": f"{aggregate_id}",
-                "time": f"{requested_time}",
+                "timestamp": f"{requested_time}",
             }
         },
         {},
@@ -32,7 +32,7 @@ def test_lambda_handles_unknown_event_type():
             "detail": {
                 "event_type": "not_an_event_type",
                 "aggregate_id": f"{aggregate_id}",
-                "time": f"{requested_time}",
+                "timestamp": f"{requested_time}",
             }
         },
         {},

--- a/tests/src/usecases/test_accounts.py
+++ b/tests/src/usecases/test_accounts.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from src.entities.accounts import (
     AccountCreated,
+    AccountCreatedPayload,
     AccountLeadTime,
     AccountRequested,
     AccountRequestedPayload,
@@ -12,23 +13,23 @@ from src.usecases.accounts import handle_account_created, handle_account_request
 requested_aggregate_event = AccountRequested(
     aggregate_id=str(uuid4()),
     event_id=str(uuid4()),
-    event_type="account_requested",
     aggregate_version=1,
-    event_version=1,
     payload=AccountRequestedPayload(timestamp=int(time())),
 )
 
-created_event = {
-    "event_type": "account_created",
-    "aggregate_id": requested_aggregate_event.aggregate_id,
-    "time": int(requested_aggregate_event.payload.timestamp + 10),
-}
+created_event = AccountCreated(
+    aggregate_id=requested_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=2,
+    payload=AccountCreatedPayload(timestamp=int(requested_aggregate_event.payload.timestamp + 10))
+)
 
-requested_event = {
-    "event_type": "account_requested",
-    "aggregate_id": requested_aggregate_event.aggregate_id,
-    "time": int(time()),
-}
+requested_event = AccountRequested(
+    aggregate_id=requested_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    payload=AccountRequestedPayload(timestamp=int(time())),
+)
 
 
 def test_handle_account_requested_returns_correct_event_type():

--- a/tests/src/usecases/test_guardrail.py
+++ b/tests/src/usecases/test_guardrail.py
@@ -15,24 +15,23 @@ from src.usecases.guardrail import handle_guardrail_activated, handle_guardrail_
 activated_aggregate_event = GuardrailActivated(
     aggregate_id=str(uuid4()),
     event_id=str(uuid4()),
-    event_type="guardrail_activated",
     aggregate_version=1,
     payload=GuardrailActivatedPayload(guardrail_id=str(uuid4()), timestamp=int(time())),
 )
 
-activated_event = {
-    "event_type": "guardrail_activated",
-    "aggregate_id": activated_aggregate_event.aggregate_id,
-    "guardrail_id": activated_aggregate_event.payload.guardrail_id,
-    "time": int(time()),
-}
+activated_event = GuardrailActivated(
+    aggregate_id=activated_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    payload=GuardrailActivatedPayload(guardrail_id=activated_aggregate_event.payload.guardrail_id, timestamp=activated_aggregate_event.payload.timestamp + 5),
+)
 
-passed_event = {
-    "event_type": "guardrail_passed",
-    "aggregate_id": activated_aggregate_event.aggregate_id,
-    "guardrail_id": activated_aggregate_event.payload.guardrail_id,
-    "time": int(activated_aggregate_event.payload.timestamp + 10),
-}
+passed_event = GuardrailPassed(
+    aggregate_id=activated_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    payload=GuardrailPassedPayload(guardrail_id=activated_aggregate_event.payload.guardrail_id, timestamp=activated_aggregate_event.payload.timestamp + 10),
+)
 
 
 def test_guardrail_activated_returns_correct_event_type():
@@ -48,12 +47,14 @@ def test_guardrail_activated_returns_activation_count():
 
 
 def test_guardrail_activated_returns_correct_activation_count():
+    activated_event.aggregate_version = 2
     assert (
         handle_guardrail_activated(activated_event, [activated_aggregate_event])[1][
             0
         ].metric_value
         == 2
     )
+
 
 def test_guardrail_activated_with_different_guardrail_ids_returns_correct_activation_count():
     second_activated_aggregate_event = GuardrailActivated(
@@ -66,6 +67,7 @@ def test_guardrail_activated_with_different_guardrail_ids_returns_correct_activa
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    activated_event.aggregate_version = 3
     assert (
         handle_guardrail_activated(activated_event, [activated_aggregate_event, second_activated_aggregate_event])[1][
             0
@@ -87,12 +89,13 @@ def test_guardrail_passed_with_history_of_passes_returns_no_metrics():
         aggregate_id=activated_aggregate_event.aggregate_id,
         event_id=str(uuid4()),
         event_type="guardrail_passed",
-        aggregate_version=2,
+        aggregate_version=1,
         payload=GuardrailPassedPayload(
             guardrail_id=activated_aggregate_event.payload.guardrail_id,
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    passed_event.aggregate_version = 2
     assert len(handle_guardrail_passed(passed_event, [passed_aggregate_event])[1]) == 0
 
 
@@ -101,16 +104,18 @@ def test_guardrail_passed_with_history_of_other_guardrail_ids_returns_no_metrics
         aggregate_id=activated_aggregate_event.aggregate_id,
         event_id=str(uuid4()),
         event_type="guardrail_activated",
-        aggregate_version=2,
+        aggregate_version=1,
         payload=GuardrailActivatedPayload(
             guardrail_id=str(uuid4()),
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    passed_event.aggregate_version = 2
     assert len(handle_guardrail_passed(passed_event, [passed_aggregate_event])[1]) == 0
 
 
 def test_guardrail_passed_with_history_returns_lead_time():
+    passed_event.aggregate_version = 2
     assert isinstance(
         handle_guardrail_passed(passed_event, [activated_aggregate_event])[1][0],
         GuardrailLeadTime,
@@ -118,6 +123,7 @@ def test_guardrail_passed_with_history_returns_lead_time():
 
 
 def test_guardrail_passed_with_history_returns_correct_lead_time():
+    passed_event.aggregate_version = 2
     assert (
         handle_guardrail_passed(passed_event, [activated_aggregate_event])[1][
             0
@@ -141,12 +147,13 @@ def test_guardrail_passed_with_different_guardrail_ids_with_history_returns_corr
         aggregate_id=activated_aggregate_event.aggregate_id,
         event_id=str(uuid4()),
         event_type="guardrail_passed",
-        aggregate_version=2,
+        aggregate_version=3,
         payload=GuardrailPassedPayload(
             guardrail_id=second_activated_aggregate_event.payload.guardrail_id,
             timestamp=int(activated_aggregate_event.payload.timestamp + 7),
         ),
     )
+    passed_event.aggregate_version = 4
     assert (
         handle_guardrail_passed(passed_event, [activated_aggregate_event, second_activated_aggregate_event, third_passed_aggregate_event])[1][
             0
@@ -166,6 +173,7 @@ def test_guardrail_passed_with_multiple_history_events_returns_correct_lead_time
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    passed_event.aggregate_version = 3
     assert (
         handle_guardrail_passed(
             passed_event, [activated_aggregate_event, second_activated_aggregate_event]
@@ -195,6 +203,7 @@ def test_guardrail_passed_returns_correct_lead_time_from_oldest_pertinent_activa
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    passed_event.aggregate_version = 4
     assert (
         handle_guardrail_passed(
             passed_event,
@@ -209,6 +218,7 @@ def test_guardrail_passed_returns_correct_lead_time_from_oldest_pertinent_activa
 
 
 def test_guardrail_passed_with_history_returns_max_activations():
+    passed_event.aggregate_version = 2
     assert isinstance(
         handle_guardrail_passed(passed_event, [activated_aggregate_event])[1][1],
         GuardrailMaxActivation,
@@ -216,6 +226,7 @@ def test_guardrail_passed_with_history_returns_max_activations():
 
 
 def test_guardrail_passed_with_history_returns_correct_max_activation():
+    passed_event.aggregate_version = 2
     assert (
         handle_guardrail_passed(passed_event, [activated_aggregate_event])[1][
             1
@@ -245,6 +256,7 @@ def test_guardrail_passed_with_different_guardrail_ids_with_history_returns_corr
             timestamp=int(activated_aggregate_event.payload.timestamp + 7),
         ),
     )
+    passed_event.aggregate_version = 4
     assert (
         handle_guardrail_passed(passed_event, [activated_aggregate_event, second_activated_aggregate_event, third_passed_aggregate_event])[1][
             1
@@ -264,6 +276,7 @@ def test_guardrail_passed_with_multiple_history_events_returns_max_activation():
             timestamp=int(activated_aggregate_event.payload.timestamp + 5),
         ),
     )
+    passed_event.aggregate_version = 3
     assert (
         handle_guardrail_passed(
             passed_event, [activated_aggregate_event, second_activated_aggregate_event]
@@ -303,6 +316,7 @@ def test_guardrail_passed_returns_correct_max_activation_from_last_pertinent_act
             timestamp=int(activated_aggregate_event.payload.timestamp + 6),
         ),
     )
+    passed_event.aggregate_version = 5
     assert (
         handle_guardrail_passed(
             passed_event,
@@ -348,6 +362,7 @@ def test_guardrail_passed_returns_correct_max_activation_from_last_pertinent_act
             timestamp=int(activated_aggregate_event.payload.timestamp + 6),
         ),
     )
+    passed_event.aggregate_version = 4
     assert (
         handle_guardrail_passed(
             passed_event,
@@ -392,6 +407,7 @@ def test_guardrail_passed_with_history_returns_correct_max_activation_from_last_
             timestamp=int(activated_aggregate_event.payload.timestamp + 6),
         ),
     )
+    passed_event.aggregate_version = 5
     assert (
         handle_guardrail_passed(
             passed_event,

--- a/tests/src/usecases/test_identity.py
+++ b/tests/src/usecases/test_identity.py
@@ -12,7 +12,7 @@ from src.entities.identity import (
 )
 
 identity_requested = IdentityRequested(
-    aggregate_id="test-identity",
+    aggregate_id=str(uuid4()),
     aggregate_version=1,
     event_id=uuid4(),
     event_version=1,
@@ -23,7 +23,7 @@ identity_requested = IdentityRequested(
 )
 
 identity_created = IdentityCreated(
-    aggregate_id="test-identity",
+    aggregate_id=identity_requested.aggregate_id,
     aggregate_version=2,
     event_id=uuid4(),
     event_version=1,
@@ -34,29 +34,14 @@ identity_created = IdentityCreated(
 )
 
 
-requested_event = {
-    "event_type": "identity_requested",
-    "aggregate_id": identity_created.aggregate_id,
-    "time": int(identity_requested.payload.timestamp),
-    "account_id": "test-account",
-}
-
-created_event = {
-    "event_type": "identity_created",
-    "aggregate_id": identity_requested.aggregate_id,
-    "time": int(identity_created.payload.timestamp),
-    "account_id": "test-account",
-}
-
-
 @pytest.fixture
 def lead_time():
-    return handle_identity_created(created_event, [identity_requested])
+    return handle_identity_created(identity_created, [identity_requested])
 
 
 def test_request_identity_returns_correct_type():
     assert isinstance(
-        handle_identity_requested(requested_event, [])[0], IdentityRequested
+        handle_identity_requested(identity_requested, [])[0], IdentityRequested
     )
 
 

--- a/tests/src/usecases/test_patch.py
+++ b/tests/src/usecases/test_patch.py
@@ -4,18 +4,22 @@ from uuid import uuid4
 from src.entities.patch import (
     PatchCompliancePercentage,
     PatchRunSummary,
+    PatchRunSummaryPayload,
 )
 from src.usecases.patch import (
     handle_patch_summary,
 )
 
-event = {
-    "event_type": "patch_run_summary",
-    "aggregate_id": str(uuid4()),
-    "time": int(time()),
-    "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
-    "successful_instances": "i-peoritdsfl",
-}
+event = PatchRunSummary(
+    aggregate_id=str(uuid4()),
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    payload=PatchRunSummaryPayload(
+        timestamp=int(time()),
+        failed_instances="i-adslkjfds,i-89dsfkjdkfj",
+        successful_instances="i-peoritdsfl",
+    ),
+)
 
 
 def test_patch_summary_returns_correct_event_type():

--- a/tests/src/usecases/test_projects.py
+++ b/tests/src/usecases/test_projects.py
@@ -3,8 +3,10 @@ from uuid import uuid4
 
 from src.entities.projects import (
     ProjectAssigned,
+    ProjectAssignedPayload,
     ProjectAssignedLeadTime,
     ProjectCreated,
+    ProjectCreatedPayload,
     ProjectLeadTime,
     ProjectRequestedPayload,
     ProjectRequested,
@@ -18,29 +20,34 @@ from src.usecases.projects import (
 requested_aggregate_event = ProjectRequested(
     aggregate_id=str(uuid4()),
     event_id=str(uuid4()),
-    event_type="project_requested",
     aggregate_version=1,
     event_version=1,
     payload=ProjectRequestedPayload(timestamp=int(time())),
 )
 
-created_event = {
-    "event_type": "project_created",
-    "aggregate_id": requested_aggregate_event.aggregate_id,
-    "time": int(requested_aggregate_event.payload.timestamp + 10),
-}
+created_event = ProjectCreated(
+    aggregate_id=requested_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    event_version=1,
+    payload=ProjectCreatedPayload(timestamp=int(requested_aggregate_event.payload.timestamp + 10)),
+)
 
-assigned_event = {
-    "event_type": "project_assigned",
-    "aggregate_id": requested_aggregate_event.aggregate_id,
-    "time": int(requested_aggregate_event.payload.timestamp + 10),
-}
+assigned_event = ProjectAssigned(
+    aggregate_id=requested_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    event_version=1,
+    payload=ProjectAssignedPayload(timestamp=int(requested_aggregate_event.payload.timestamp + 10)),
+)
 
-requested_event = {
-    "event_type": "project_requested",
-    "aggregate_id": requested_aggregate_event.aggregate_id,
-    "time": int(time()),
-}
+requested_event = ProjectRequested(
+    aggregate_id=requested_aggregate_event.aggregate_id,
+    event_id=str(uuid4()),
+    aggregate_version=1,
+    event_version=1,
+    payload=ProjectRequestedPayload(timestamp=int(time())),
+)
 
 
 def test_handle_project_requested_returns_correct_event_type():
@@ -54,6 +61,7 @@ def test_handle_project_requested_returns_no_metric():
 
 
 def test_handle_project_assigned_returns_correct_event_type():
+    assigned_event.aggregate_version = 2
     assert isinstance(
         handle_project_assigned(assigned_event, [requested_aggregate_event])[0],
         ProjectAssigned,
@@ -61,6 +69,7 @@ def test_handle_project_assigned_returns_correct_event_type():
 
 
 def test_handle_project_assigned_returns_correct_metric_type():
+    assigned_event.aggregate_version = 2
     assert isinstance(
         handle_project_assigned(assigned_event, [requested_aggregate_event])[1][0],
         ProjectAssignedLeadTime,
@@ -68,6 +77,7 @@ def test_handle_project_assigned_returns_correct_metric_type():
 
 
 def test_handle_project_assigned_returns_correct_metric_value():
+    assigned_event.aggregate_version = 2
     assert (
         handle_project_assigned(assigned_event, [requested_aggregate_event])[1][
             0
@@ -77,6 +87,7 @@ def test_handle_project_assigned_returns_correct_metric_value():
 
 
 def test_handle_project_created_returns_correct_event_type():
+    created_event.aggregate_version = 2
     assert isinstance(
         handle_project_created(created_event, [requested_aggregate_event])[0],
         ProjectCreated,
@@ -84,6 +95,7 @@ def test_handle_project_created_returns_correct_event_type():
 
 
 def test_handle_project_created_returns_correct_metric_type():
+    created_event.aggregate_version = 2
     assert isinstance(
         handle_project_created(created_event, [requested_aggregate_event])[1][0],
         ProjectLeadTime,
@@ -91,6 +103,7 @@ def test_handle_project_created_returns_correct_metric_type():
 
 
 def test_handle_project_created_returns_correct_metric_value():
+    created_event.aggregate_version = 2
     assert (
         handle_project_created(created_event, [requested_aggregate_event])[1][
             0


### PR DESCRIPTION
- Simplify incoming core event creation by bringing it all into the controller. Reduce repetitive code.
- Standardise time variables to timestamp.
- Clean up/add more useful logging.