### PR TITLE
Update bigquery driver and add tests

### DIFF
--- a/.github/workflows/aws_cicd.yaml
+++ b/.github/workflows/aws_cicd.yaml
@@ -44,9 +44,6 @@ jobs:
       - name: Install pip packages
         run: make install-dependencies
 
-      - name: Perform unittest
-        run: make unittest
-
       - name: Plan terraform configuration
         run: make aws-plan-all
 
@@ -61,10 +58,10 @@ jobs:
         run: make aws-deploy-all INFRA_ARGS=--auto-approve
 
       - name: Perform full test and check coverage
-        run: make test
+        run: make aws-test
 
       - name: Conduct e2e testing
-        run: make e2e
+        run: make aws-e2e
 
       - name: Configure prod AWS credentials
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,14 +12,18 @@ jobs:
   pip-audit:
     uses: ./.github/workflows/pip-audit.yaml
 
+  unit-test:
+    uses: ./.github/workflows/unit-test.yaml
+    secrets: inherit
+
   aws:
     uses: ./.github/workflows/aws_cicd.yaml
-    needs: [pip-audit]
+    needs: [pip-audit, unit-test]
 
   gcp:
     uses: ./.github/workflows/gcp_cicd.yaml
     secrets: inherit
-    needs: [pip-audit]
+    needs: [pip-audit, unit-test]
 
   # slsa:
   #   uses: ./.github/workflows/provenance.yaml

--- a/.github/workflows/gcp_cicd.yaml
+++ b/.github/workflows/gcp_cicd.yaml
@@ -64,8 +64,8 @@ jobs:
       - name: Deploy main infrastructure
         run: make gcp-deploy-core INFRA_ARGS=--auto-approve
 
-      # - name: Perform full test and check coverage
-      #   run: make test
+      - name: Perform full test and check coverage
+        run: make gcp-test
 
-      # - name: Conduct e2e testing
-      #   run: make e2e
+      - name: Conduct e2e testing
+        run: make gcp-e2e

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,25 @@
+name: unit-test
+on:
+  workflow_call:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install pip packages
+        run: make install-dependencies
+
+      - name: Perform unittest
+        run: make unittest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED True
+ENV BIGQUERY_EVENTS_TABLE=contino-squad0-fc.event_sourcing_table.events_data
+ENV BIGQUERY_METRICS_TABLE=contino-squad0-fc.metric_sourcing_table.metrics_data
 
 COPY requirements.txt ./
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4847855cfa4ff272eb66cf1fc9542068ada6d4816d56573cc9cafde51962d0ef",
-                "sha256:ec53175eaf818dfe1eec33f7e165eca957744c1d8a82047a9efbcce9547e5cc9"
+                "sha256:d45672571da9bf4ba130d525832013aef95aee83b1711e847ef7cdb54cc5ac41",
+                "sha256:e579b70028cdc4194fe92c745256b04880e7db39259a4c8a61b71117713d3c17"
             ],
             "index": "pypi",
-            "version": "==1.26.124"
+            "version": "==1.26.132"
         },
         "botocore": {
             "hashes": [
-                "sha256:cbcbd5b084952d332d7b8170577f10509e3e7b3b6abbc2920b1c27e93ad2ab25",
-                "sha256:ebe8a83dd1db18180774ce45b1911959c60bb1843ea0db610231495527a3518a"
+                "sha256:422186c13406a2c2668e4b2d9070097b4b024a9290a6af2a8e21eb2bd17322d6",
+                "sha256:9b6d2b60325b815ff9123f172af83b7b866c8813088d969eeb9030fa189417f6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.124"
+            "version": "==1.29.132"
         },
         "cachetools": {
             "hashes": [
@@ -58,11 +58,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
-                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
+                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
+                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.12.7"
+            "version": "==2023.5.7"
         },
         "charset-normalizer": {
             "hashes": [
@@ -174,11 +174,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:ce311e2bc58b130fddf316df57c9b3943c2a7b4f6ec31de9663a9333e4064efc",
-                "sha256:f586b274d3eb7bd932ea424b1c702a30e0393a2e2bc4ca3eae8263ffd8be229f"
+                "sha256:c66b488a8b005b23ccb97b1198b6cece516c91869091ac5b7c267422db2733c7",
+                "sha256:ef3f3a67fa54d421a1c155864570f9a8de9179cedc937bda496b7a8ca338e936"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.17.3"
+            "version": "==2.18.0"
         },
         "google-cloud-bigquery": {
             "hashes": [
@@ -198,11 +198,11 @@
         },
         "google-cloud-pubsub": {
             "hashes": [
-                "sha256:587da7d535ca858ceeed7036205355e5a6dd3e44ea4abc96f4e50d1abfd8843b",
-                "sha256:e41ec9635cc68dbd238f572f295b3d0bae6340c66ba31a70dfb890950ab33c2b"
+                "sha256:31e271be755ed7143ae0cdfed0506faf40d7504b46fa5c8b5bab4b922f6c3d3b",
+                "sha256:5bb4f2a6d2d0bf827d48dca1de1fb0ca12636ed75a69bbc4f89d231239b65ad9"
             ],
             "index": "pypi",
-            "version": "==2.16.0"
+            "version": "==2.16.1"
         },
         "google-crc32c": {
             "hashes": [
@@ -483,22 +483,22 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:0a3d1a3f746cc5209163bab06f4f56b77fb9d523beedd42e04e6334bb653fd84",
-                "sha256:139682756712146b24fb276c800dc7d05057136b331b66cd2a31f68e55dbac6f",
-                "sha256:33673619f4f28b04f4e99b578ceb99b335b31ee5f5a2cc513a9d32284ff8d956",
-                "sha256:3979ea994d7bf9fcbc7541b7cf2331c0850896d20db099d9d22cc6f01627ee68",
-                "sha256:499e5884e71719de45baeec980ea2c46a4fabe83a240363ea3272507f4819771",
-                "sha256:6d7c54c6686462f06b0f19d5c4cc1ce86be247493b89ed6cdb37f7b5f02f26ee",
-                "sha256:87af9d12258b4f3602dc26417db9dc89204d029647d5cf0de7d9d819fbd5b35c",
-                "sha256:a24d1498edef52e4a17f67b7640e1973f9affc168f15fe6d9eff4cb1ede785ea",
-                "sha256:a49938ad67a8652d64b662be6841e29764cd44d6db7e0be2f8c9d7a68c53b129",
-                "sha256:ba9e9279844e49a734accb0696f929615c59226176d585a341ccc51e85431e39",
-                "sha256:be3791a2694b96008334e8072845eaf5c7d4bce4564cf126ecbc34d3bf5abcdc",
-                "sha256:cf6904fabb6ef00c8bd0b666b196584af333442b05c044c492a09f743d31db6f",
-                "sha256:e7e5bca11a5ff3bc4919aaf80bc83781b6ea093b77f60743f766f1af2aec68e4"
+                "sha256:03eee35b60317112a72d19c54d0bff7bc58ff12fea4cd7b018232bd99758ffdf",
+                "sha256:2b94bd6df92d71bd1234a2ffe7ce96ddf6d10cf637a18d6b55ad0a89fbb7fc21",
+                "sha256:36f5370a930cb77c8ad2f4135590c672d0d2c72d4a707c7d0058dce4b4b4a598",
+                "sha256:5f1eba1da2a2f3f7df469fccddef3cc060b8a16cfe3cc65961ad36b4dbcf59c5",
+                "sha256:6c16657d6717a0c62d5d740cb354fbad1b0d8cb811669e06fc1caa0ff4799ddd",
+                "sha256:6fe180b56e1169d72ecc4acbd39186339aed20af5384531b8e8979b02bbee159",
+                "sha256:7cb5b9a05ce52c6a782bb97de52679bd3438ff2b7460eff5da348db65650f227",
+                "sha256:9744e934ea5855d12191040ea198eaf704ac78665d365a89d9572e3b627c2688",
+                "sha256:9f5a0fbfcdcc364f3986f9ed9f8bb1328fb84114fd790423ff3d7fdb0f85c2d1",
+                "sha256:baca40d067dddd62141a129f244703160d278648b569e90bb0e3753067644711",
+                "sha256:d5a35ff54e3f62e8fc7be02bb0d2fbc212bba1a5a9cc2748090690093996f07b",
+                "sha256:e62fb869762b4ba18666370e2f8a18f17f8ab92dd4467295c6d38be6f8fef60b",
+                "sha256:ebde3a023b8e11bfa6c890ef34cd6a8b47d586f26135e86c21344fe433daf2e2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.23.0rc2"
+            "version": "==4.23.0"
         },
         "pyasn1": {
             "hashes": [
@@ -518,98 +518,98 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:3fcf5a31489ba491b4519fb75f86d03d221a938bc8e794453cd2cfce75cb76a5",
-                "sha256:4bbd961e806eeeb5c9489c7352fb2cfcd0c58f80e0702065b251ce309fc8f6ec"
+                "sha256:720884809bae5cb5358914e45da63dd61369917749d55ab80a7427aa4ca5dcf7",
+                "sha256:7a99e0616ca53fa53079f28d941370e491ee84e7657f2681b50ca0a41390a266"
             ],
             "index": "pypi",
-            "version": "==2.0a3"
+            "version": "==2.0a4"
         },
         "pydantic-core": {
             "hashes": [
-                "sha256:00157f52a367d2763e05879d31d7369e22e53e6e1e196a66607452d3d229960a",
-                "sha256:01a0c73f018f6969e1e7393bfa0cac999c46d3ab80a8224ed15b0c641dfc96b2",
-                "sha256:0254dce1639811384a806a77eedd24bd03554cbdafba094b03c95ba0325b5b74",
-                "sha256:03a152d69d5849a6820023806b8198b398b79f675ce6f72cc5a0a9ab2922a858",
-                "sha256:09a7997b8c44353d36e7a14f7eebf9c45595709198d6dd73d8b0b1f3423ec42b",
-                "sha256:09d0446252d93e1a1d4e669fc2eb429b42e66b1dd251145ebb8d17623bfc6fcc",
-                "sha256:0c243c29bba9eb8132da3a9993a69dc295af6205f751a5d4458ff5dcdf80644c",
-                "sha256:0fcc69217de13a6f8a926a37946e0901aec0c9b66259dde260584cd911c97aa5",
-                "sha256:149c60c812ace1262008d186193a6c856d980e1913e0f7263b46c26321009efb",
-                "sha256:15f6633fe7259e5f65ef8fd44fefc0969ab2f68744b12522ebe97e0c1fd46517",
-                "sha256:17da247e12503862fe2450812cf71739787b2d813408d301bd9ba1c111167b98",
-                "sha256:1a20d538c8538f8c75ea5341dc21f94ef1882db86f2f2fd4fc61ee2a4419813a",
-                "sha256:1aad4545ebfa5984095970d88c2366d6b8de2d5716f3f416ef814048371b62d0",
-                "sha256:239ae3b0cb209244cd8d3cd74ffef0e20602aaa4c7d2718a405c324d1c7af5f0",
-                "sha256:24fcfbcf31b998b4e382fb192ca6d929b32f380132dd607610290fad040e5656",
-                "sha256:26254d3012c823c7f26d81644027a096d83c914c6f5c0893e244a9333c7aa243",
-                "sha256:28739b0cc481dde1189ded7d691a181d61d2a8c7e503be06694bdce3586e3ecd",
-                "sha256:2ba13d173bdd8d5d3b8d8c865cb9164bab1e9da7fd1f1fe21d3e88f3f53bfca6",
-                "sha256:2c919d41c8e17b89d706825b7ad53a1d5834503b8222545c4751efff08cc3e8f",
-                "sha256:2fb489cd9e53efa4ea88f6c9b7cf8e4bba3cad42df3a9781bd30c072617ce1a0",
-                "sha256:2fb90b6df8feafc95dcd708f0bf8fbca2413f686425c0ab41916872b26ee635a",
-                "sha256:35e0f3ad3817845e48b51369a602efe4cebff1127352de1551263bc5a8392399",
-                "sha256:36fb117df24151ee0740e99f16f183054dfbfa7d2d0b74df195a929bb59d8259",
-                "sha256:3d76b5f7d01d2f58e34ff7460c30ee61f9a1db885a568b7904bd943c916bcd3b",
-                "sha256:3fc30e7dcbc962edb649facd8d963df3c958ee762a66bc0e6bb43050497437e1",
-                "sha256:4363bbcf28a1230b71c2437cd98234e00402bb6fd48026a134230760ca69e715",
-                "sha256:43d5eb23050ba96d4f1d6f00198e8fa0d85341cfc61151d07b755f1877b4bea5",
-                "sha256:4618813403b1fca7f417f1604b59c4bbe7a637275bcccff30d92b31eeffaec6e",
-                "sha256:4955568b102d57b099a3c8ec8e91f480986c55b761d3a46b69583f1381a157e6",
-                "sha256:4f88b38b223893c183d733572b815a6931adaeaaed5c986e480ea47d3f94ff67",
-                "sha256:52915248c47d414f75ccdbb496499ee83faff3a982b8886580c8dae58d411928",
-                "sha256:56552d6a75d2a06e7fa1fb355d6b43404490f270c49db3cd251ef074762d8c5e",
-                "sha256:58b65440b8149439f541910a71c0ccf23c388553b9539c25ebebaa95759c4017",
-                "sha256:5d4e50a162d119389d7c4f0ba00021e00ec3a0b62069bf8e55cd296149a10442",
-                "sha256:5e4f28e67d338fb7ccc38ee39dcd35fe88ff72d2ab71336768b50077a19d4142",
-                "sha256:6234592624e74ce3b397fba6f30688a74768fed107b30bad21d44f472b243bd4",
-                "sha256:64a4fef2ff3f8e63aedc24bd8b0f4dfdd117082ec90671ea4518d51d3a21df23",
-                "sha256:6d52e17b211a304f6375ef529b21869c573b866ab2bd1bf5aeba46780e7b8359",
-                "sha256:6ed58ce669d13c076095adaea3331f48ab914485eb1ce6f462c08c982edf935e",
-                "sha256:73287ea35d999332e443dbbdf3b9eb963c516e113bacb7f609735562a16ecc84",
-                "sha256:78df29c6c8bbdb02c27443a7b9b6a32281138c92d675a0ff0891eca6657fda9f",
-                "sha256:7a548b1bdefd5d5a87dd064343e5b78e9bf7b66c64c4d2b26706f58e8f2594b6",
-                "sha256:7e324e608e1650ccac731ae6077c7bf86f88a930a6e71b412dbe53106008e53d",
-                "sha256:82bcd983fc15064928d62ade5f0352058e4ee02e809d74847e9f6d0e24736add",
-                "sha256:8bb82dac1f0d34383b0a819544ba4c37e69a8f72c0d6e6dbbe29746147de28a3",
-                "sha256:8e0150ca25eeb7836aeb37ca05dd22f167d74a25fad100d58f93c20ff063c934",
-                "sha256:914ad3974d07dc17c65f46df9c896a54ac51c8bc6c657c4ab415b5d59de894cc",
-                "sha256:92a8b8542929f40718cb58638f46c99fcd2470c8b58d50c5fad5facac5b2fe00",
-                "sha256:93cd520418048e4ab012dba62e2cbd59f60199036a77b1e120d06f1e126232e3",
-                "sha256:97eb6422689eb714cc1f5af5d220cbbcbfbbb3778dc80f6edb578df42c94bef2",
-                "sha256:9b5d094ad5728454e14115fed93766ae5ab89aacc218d4c641eb148bfdf0b555",
-                "sha256:a2a06dc032524cdad60d1a56d6a467ca649b633a6ad0315033b1d590377ade21",
-                "sha256:a582fb6be0941db143944ec9f3e223d943c5410a963f969e1c813e0d941d5e30",
-                "sha256:a68366aae4fc15b7738aacd910b10f432296f03f5fc3b622b68f4bca901206b3",
-                "sha256:a78542cf83fa81760bc515242c7508bacca8378ebdf7f081674e0d7d07186157",
-                "sha256:aa3786722b293be9e8dde8a8d72cc9ed3412589755970876de6ac4167d3c0a87",
-                "sha256:ab006970f59350f538fc01dfd1ee4fd15689490471dfc02bd68503845cd4e474",
-                "sha256:ace2e31043892352fed279fd6c1495bc66043d74b6fb04c3868e6056d3d07642",
-                "sha256:aec5b257f40f66a81df35fa9381e84dc4945ec20e1a99006a832d2bd7c730ab2",
-                "sha256:b381b02c5c70e56f9d39263ab872fe1c40d73f4609ec0d5b57c2a0489bb579d2",
-                "sha256:b45581c01d6ee27c0390aa49eb2c19eaa47a6f0f0cab7fe282a9680402d1b014",
-                "sha256:b4fa2fbc2e4273c863abf14a73d4182b17d8d85ec5ad795de8c31dd7921a9738",
-                "sha256:b756443ba2ec6295236da587fe91a0ba99bd9131416e6163a000ae58e4724ae0",
-                "sha256:b7a35610fe3c65334dc48ed6abeb459643a0becbd95a507ac3581da80d7f7a28",
-                "sha256:b8358f18c1090293d6e22ed14a1ad6940421d2a10f9f276c8a2119ef5697ea67",
-                "sha256:b9ede8cf2dce74599f5e90850330ecf8c0ef67575d7bc6ccda682714910b6c69",
-                "sha256:bb7bb8ecb02180d62a9c751f44a5b1f126d582a866c02372f1b922a6a8e872b4",
-                "sha256:bc704bc051636ef8ef0d75d64a1e6094f96d188ca0cd772048ebbbf6863d8fc8",
-                "sha256:bf0de2e8f2bb0a8178a9c861a7e4cf820ddf5cab93af4f78c962e0f1c8391b38",
-                "sha256:bff3ac8f17065e463402597f8c71c2c09045e7391a6e22ef9b43ec1c7f14999b",
-                "sha256:c81c8f78ccfe24de9a834e0c0ea1c78d9a61460b925402f4b8fd4e87ac7ba270",
-                "sha256:ce0b300f5f50dfc70bf9c5eaf525600cd420c7611b0b0dc6ec62458717e955ee",
-                "sha256:d4059c7c0e4ecf986bc864579820176e13f0896b3e0dd3b72c96298015cc1788",
-                "sha256:d71a45a30286b93728c0de71733128589934008ee906b826dbcffe9fdb1d343c",
-                "sha256:db6f00e16273f24342a5ed1c44aaf533c70e087d5daab01debc383015e75dde9",
-                "sha256:ded1aabeb5f358c5ae984137e123bdb547abfa96c8f673300f8498ce832c1b9c",
-                "sha256:f1f636d2c39f694cbe82645ade8d27250fadac48bd1d47648dd0f38a487f8c51",
-                "sha256:f875acdcd51c0c72bdb046be5e1f979731ec97ed5102c55049188cd2f20a76be",
-                "sha256:fa5af4d978744e493184ecc334f23b91f93c1bf700a88fd91a6883369ab8d276",
-                "sha256:fc17c9256540b688cd67fd3deef77dcff04ee8afe609ba418b15b43124fbc482",
-                "sha256:fc8441277e75ef2026f00584511be92a8824a0ae7304fa51c8b48962665ec3c4"
+                "sha256:01b79683e39b4051bd8c252803f6f02748f781224eabcc2532e266be213f9b8b",
+                "sha256:0391275cd3217852a5b3737719e9115cc34587917bce7bb238ec7a0189b82d60",
+                "sha256:039bd499abf1096c9610cca40d30db0a8609105897a694766685ecb464018d8b",
+                "sha256:0bd9fcfc946cef379b3f19658b92fadf9b0ee2e889f4bf81248b946849f4561e",
+                "sha256:0de7b6f03b28deb52ac50bda0f9e716ea8cb99f4181d8ee1cf967c0bcae593da",
+                "sha256:0deed36ad1ffbe8437b110f2183266ca5eb49c4928e3659320aa67963e6b791c",
+                "sha256:1128eca605524b5c9b7dda7f40671a902c20ffff9226ffeebc5eb7c937ae01dd",
+                "sha256:12dbbd61aa6f1bae703dc01f6135a1c5a9449ced8b44f7a9329e0ec9c07dfa20",
+                "sha256:149715aae43717365dcbb3e5ee7c946cc325128e83e440a8f9fb9a0e4d6e0c8a",
+                "sha256:17f94d72dcb235e75fdabb5e8d5e447e8f206ab5fe46ae1aacb82c6584bbd5a9",
+                "sha256:1dce7cfe4abf11b348d82d72a2020860055340cd35462b8019792f09cbde020b",
+                "sha256:1e0c605c2f38983c82cb7a4ae80cb392335f5e32b9f9e7a42d41fd1ec8790201",
+                "sha256:1f3749a40d4417ab1a012219ebc88fd1c9644c8aa24a70b453bc20e46e18d7af",
+                "sha256:2f3d03af970c5e66a1eb6e3edffb893978f65316a7d7a195abae5b843ff21c41",
+                "sha256:3015f3127ae65e7951ff93864a2edadd53e3971813418f4f81e066e1ad608527",
+                "sha256:36cc68b42f1f0bf4e95f5de03af028afb03c2c110513a9551d1b1ea0f018e574",
+                "sha256:3e28cf11395c5b9ad3baef8f5fb8a5f4bdc6367366167cc41b944347d7b484af",
+                "sha256:3fd5e452dedef2ede82aa8bcdf0bce0467d6f3de092077b335ba8d724d94450f",
+                "sha256:40a59efdaa88679239dfb7e199540967352e1122c15ef34c791984fd732f8128",
+                "sha256:42a5f5f4fc2e08284a90aced31384ffddfbda25370bd5cda876ffe3aa2ce67e2",
+                "sha256:4e39f4c7550c8aa698963a3840f6f26c55b2596be0f539694d1cb31baf89169d",
+                "sha256:4f08b4a27b2e3f03e10f88fe304c8882f87f841190bde20f1b7ae6bdc1b1606d",
+                "sha256:52a67a02f65c1e90379481f0b4e68dea3736becb9ede94f25e9023258211e21c",
+                "sha256:53648ff27598402eb966771bf0c1b50738f26b7678d6aae45107ccf30644b0cd",
+                "sha256:563604dc3b91ee14ecdce9efdd07024b0f3452d629a9f4cbb063863dacbc1915",
+                "sha256:5a69abfb4a3488ffbb49a4f65ffa3230aa9b0e2664daf2814faa144cd531c681",
+                "sha256:5b9a004732d7a153f7cfc30ea30d2bbd653f42be1ce5995b848d02fcbed9add2",
+                "sha256:5d349c8dbdf7f6f41540f3443df37e6b9fff474f6c056ff9f1a3dc9796ddb6e4",
+                "sha256:60403f87cf1ad7cc2b3231b15160c3fb751240ebf8df67299ab80569a15da040",
+                "sha256:6079970c2f260ba4040bee9664665aca5d3f2927ac416342b77bb19bebce1ef8",
+                "sha256:642ff3f767766e14bd8273814351291967c3ce084abf50ece0d69d5dbb53ddab",
+                "sha256:6c569ebc7ec97c3c0e2fedcf4b921710a2c7772b66a3ba3edb1e999ddb54d5ee",
+                "sha256:705d8439bf845e11f477462eb092b1e0dcd9219fa3a07d03893745a6e8f894a2",
+                "sha256:75d00e82d4917417104d88c275dbde0291bea753e763642c8a6301303e8a8491",
+                "sha256:785100c6c5a87b57c247b17f2fb1130022c423079a9d666fee44fc25d43fd9bf",
+                "sha256:7d1025eb05dea39fc28f1df69669122900e226d60b1d50cd6a34293a1e769a19",
+                "sha256:8095585d673d40100046730253ac8de5a48b06754fccb3b8ec00a0e2b1b8a813",
+                "sha256:834de30faba6b5384b9206cfea008bf0e02910749cbbd9bfae3aed3ebdc94603",
+                "sha256:88383d06a5d8edd2bfefca2576a7a84da1553e305b16d5778bedc5bdf8235759",
+                "sha256:89913535b1854b354d703516ac09a82da16a1c06074b9302c1f371e8ed89c837",
+                "sha256:8a71465d22a8d06b2ddb91f40680e27a85c08b37f87f1a8b51da9fa84e30f8c8",
+                "sha256:8e81efb5ee607460db350212039d709833e8e39d04a75f2b141c305531aa60b9",
+                "sha256:8f1ddd33f835de28ec550606e4f1682f37c8a896e52c6c52a53fdd192c9db9ec",
+                "sha256:91bc9de6a0527dc8e5834371a60aabfa13e1b7a06006848f90aa710ec84d1c78",
+                "sha256:969cd903837a6fbc107585fb5b099cb6dc22b3e75ffd8a9f00bd2e1e0454832b",
+                "sha256:983c1d49d0ef1c91e0ade07db210986334aaba5a1ce9373dfcb0d6077f7b1a26",
+                "sha256:9a7a42a48281fdc0ac073d80319597dd097d096b8490fac084085c8aa349fc98",
+                "sha256:9d47a099b0db8001991010a482911e86448b877406eb8834492282b300ea034d",
+                "sha256:9f9b078bbd1b018e9e358efdd452bdfdb9a419474fbe5d069fabe677d2993b41",
+                "sha256:a1f4bdf92326e0ac1150783401660ffd0bf522503eefbdf9ac95555aac41f0a2",
+                "sha256:a7f35ff6cc7d9cbc33cb6e7784f958998782fe41aff6f75761c44756ff3ef072",
+                "sha256:aa7718c9d78a8d6ffcadb247bbcac7d397576786823371a0473fdf6feb94d0a7",
+                "sha256:ab726880e9e3ddfb6ae2b7dbef551f39716d50728f4a0c89ff9d84d0cee18388",
+                "sha256:ac9a2e4a208a84467e311a1f86ac6dcfe8ff1215099f5886ce07134e32844a11",
+                "sha256:ae2b6d20110d5fcc9439e2e6da5da3306a8a5789ea90921406ae3fea7e6d555e",
+                "sha256:b5027e588663b7baab6be5b4c41e6303a0844167ed619da488cdf248f8316b74",
+                "sha256:b7d1ad4d57d76d0a48d708e51160306056ecf8312cdab4727bae19e99a98e103",
+                "sha256:b9bcf7d37d55904df6cabd96ac63c1daf383211d20d1325bab50d53554c83184",
+                "sha256:bb6c7542ef8668a5ec4d25fdf9b028acedae6aaabb89afbc2664751922c714d6",
+                "sha256:bc9f09c8e6ed23453d7a5adde29fea83d4464182e98bd83b11747f1796e9e0d4",
+                "sha256:bda084bc748b3b0778cff7600dbb82daf6c45f1d29cab18e0ac6be19f300cfd0",
+                "sha256:c608c02bae0e108ae1f0c52520b77ed2d1f8ea7c0927620ca5527982413d292e",
+                "sha256:cc6d5c107467408e1600a6482ec22d922aad30826f5789e188bda8957c4d4922",
+                "sha256:cce350b72222b8624b5bc822f7d20901942122fdf8ea727967a14afb1fba6e55",
+                "sha256:ccf97d97659181352dc96dc3b145a390bd63f3641baab493cbb9281312715d37",
+                "sha256:d05ee5a2ce0aef536471f470194136b211b0027024bd18a6ac58cd23aa2806a5",
+                "sha256:db2478efd4fe2445cc545080e07c5a169c3ca8455db42695ce8b3dff3d571e83",
+                "sha256:dd2e61db3d0c7e172a6f0ab010740f8ace86aa695f5b80a7d185cf84c501d5d8",
+                "sha256:de67ac6952a73a9474a7c0fcc03be221958c45de638b990d02ea9b68e9829492",
+                "sha256:de69fb25f6718a8fb3648899981c48fbda7d9317a9f367e2bd19fa78482df8c0",
+                "sha256:e2856f7039a6f7815013768d82de119c2da4b8b6502ef1d94fcc664d329c928e",
+                "sha256:e45e7347ab2e7752c716d43df5459569385d96fcec00e4d21159041e8150dec3",
+                "sha256:e5f3ad194c53bc2a38c92bb25844dc3dd0a3e45147796f3397bd4416370266cf",
+                "sha256:e6b852f20dfd9c5a64a871e012fc0a6532580a606214e1354dec59ec79a4ec9e",
+                "sha256:e805567a747807cdf160d4a1adedc102374424ed18f0cf7d2c33a6bae4e655ca",
+                "sha256:eb449596ff89245df4ac6e993690a57290afcdb6be3f545cd31cd1e5be33306a",
+                "sha256:ecd4aa9f2c4e6eddfdc4392d7021428e436ffcbbde054e08d3d6b92e48235eaa",
+                "sha256:f093fa3630212744810b32895720af899209820cb76be4146fb099c20c9cf624",
+                "sha256:f4e04f6c53fc5cb635358bad318d021fcfe07bc92b2f30ddf6b16c5ccecc761d",
+                "sha256:f98cdd14b6c0bd24e555188b00399b2c6eebbfa97a1744ad83afbeb0559302a5",
+                "sha256:fe037bd9acc5a52843ee95d6a9a69f92d51fdc09c882e54f052223fa52e4b5b7"
             ],
             "index": "pypi",
-            "version": "==0.25.0"
+            "version": "==0.30.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -621,11 +621,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
-                "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"
+                "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294",
+                "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.29.0"
+            "version": "==2.30.0"
         },
         "rsa": {
             "hashes": [
@@ -637,11 +637,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd",
-                "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"
+                "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
+                "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.0"
+            "version": "==0.6.1"
         },
         "setuptools": {
             "hashes": [
@@ -685,11 +685,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:4866679a0722de00796a74086238bb3b98d90f423f05de039abb09315487254a",
-                "sha256:a987caf1092edc7523edb139edb20c70571c4a8d5eed02e0b547b4739174d091"
+                "sha256:1d5a58e0377d1fe39d061a5de4469e414e78ccb1e1e59c0f5ad6fa1c36c52b76",
+                "sha256:48e5e61472fee0ddee27ebad085614ebedb7af41e88f687aaf881afb723a162f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.3.3"
+            "version": "==2.3.4"
         },
         "zipp": {
             "hashes": [
@@ -703,11 +703,11 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "behave": {
             "hashes": [
@@ -766,19 +766,19 @@
         },
         "cdktf-cdktf-provider-aws": {
             "hashes": [
-                "sha256:9f33386e3d01506e644bd68822774cfd362ed2dd920f39dc54fc8b959a38d3c1",
-                "sha256:b56a816657947ac82e24977d33250226d93a34d12f8a6ead3a26afc16d8bc5bc"
+                "sha256:02d9cdc5a5305ff4c5088c031d20624bcb4c8538862cf1efe09abca339d8f5d2",
+                "sha256:68ab3b2622551a6276b3e3150f2903efba645bbb3c5c71cd4968c54aef2bd8ac"
             ],
             "index": "pypi",
-            "version": "==14.0.2"
+            "version": "==14.0.4"
         },
         "cdktf-cdktf-provider-google": {
             "hashes": [
-                "sha256:12d6063eeb28db74287ceea6b5e3702dbf4cd3ce559ece6bda15276852815e88",
-                "sha256:5e241059e61b51dc04f943346133ab5a1e4dc1750f9a73d69d9e5fb782ed0852"
+                "sha256:89c5a0893ee4557d906363c9896ac6c9d4653a67ef065e16991bebedce452c99",
+                "sha256:d5ac32d872b623a3bb89a66def8775fc78aab0bdf9e307736f0a31024240ac72"
             ],
             "index": "pypi",
-            "version": "==7.0.3"
+            "version": "==7.0.4"
         },
         "click": {
             "hashes": [
@@ -798,11 +798,11 @@
         },
         "constructs": {
             "hashes": [
-                "sha256:14cdcd5b53372ede2a962984a0ec69c4ffbfbec47f43c5e6da3fb366e371f6b6",
-                "sha256:bee9d3b882a33f80a907495801bc7b6f3382023adeae90ab8f141f7f4e61878e"
+                "sha256:6d1d29386759916ddc6fc60a29e707a74d1046988180145cec285b67136de74c",
+                "sha256:a84fb834dc35b785c6850e4c6f0d9590227ce8f0cf535b93aaab77889f13b9cf"
             ],
             "index": "pypi",
-            "version": "==10.2.13"
+            "version": "==10.2.19"
         },
         "coverage": {
             "extras": [
@@ -928,11 +928,11 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:4da63ab99f2696cd063574460c94221f0a7de9d345e71dfb19dfbcecf8ca8355",
-                "sha256:ea3cace063f6a47cdf0a74c929618d779efab426fedb7692a8ac1b9b29797f8c"
+                "sha256:585f6bedd9b586f48ce058451d24f362ee52936179987dd897a100f5355f228f",
+                "sha256:6d12cd881053bafbac19d2a28fc616497479739784e017534e4cf128ff977b62"
             ],
             "markers": "python_version ~= '3.7'",
-            "version": "==1.80.0"
+            "version": "==1.81.0"
         },
         "markupsafe": {
             "hashes": [
@@ -992,35 +992,35 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:023fe9e618182ca6317ae89833ba422c411469156b690fde6a315ad10695a521",
-                "sha256:031fc69c9a7e12bcc5660b74122ed84b3f1c505e762cc4296884096c6d8ee140",
-                "sha256:2de7babe398cb7a85ac7f1fd5c42f396c215ab3eff731b4d761d68d0f6a80f48",
-                "sha256:2e93a8a553e0394b26c4ca683923b85a69f7ccdc0139e6acd1354cc884fe0128",
-                "sha256:390bc685ec209ada4e9d35068ac6988c60160b2b703072d2850457b62499e336",
-                "sha256:3a2d219775a120581a0ae8ca392b31f238d452729adbcb6892fa89688cb8306a",
-                "sha256:3efde4af6f2d3ccf58ae825495dbb8d74abd6d176ee686ce2ab19bd025273f41",
-                "sha256:4a99fe1768925e4a139aace8f3fb66db3576ee1c30b9c0f70f744ead7e329c9f",
-                "sha256:4b41412df69ec06ab141808d12e0bf2823717b1c363bd77b4c0820feaa37249e",
-                "sha256:4c8d8c6b80aa4a1689f2a179d31d86ae1367ea4a12855cc13aa3ba24bb36b2d8",
-                "sha256:4d19f1a239d59f10fdc31263d48b7937c585810288376671eaf75380b074f238",
-                "sha256:4e4a682b3f2489d218751981639cffc4e281d548f9d517addfd5a2917ac78119",
-                "sha256:695c45cea7e8abb6f088a34a6034b1d273122e5530aeebb9c09626cea6dca4cb",
-                "sha256:701189408b460a2ff42b984e6bd45c3f41f0ac9f5f58b8873bbedc511900086d",
-                "sha256:70894c5345bea98321a2fe84df35f43ee7bb0feec117a71420c60459fc3e1eed",
-                "sha256:8293a216e902ac12779eb7a08f2bc39ec6c878d7c6025aa59464e0c4c16f7eb9",
-                "sha256:8d26b513225ffd3eacece727f4387bdce6469192ef029ca9dd469940158bc89e",
-                "sha256:a197ad3a774f8e74f21e428f0de7f60ad26a8d23437b69638aac2764d1e06a6a",
-                "sha256:bea55fc25b96c53affab852ad94bf111a3083bc1d8b0c76a61dd101d8a388cf5",
-                "sha256:c9a084bce1061e55cdc0493a2ad890375af359c766b8ac311ac8120d3a472950",
-                "sha256:d0e9464a0af6715852267bf29c9553e4555b61f5904a4fc538547a4d67617937",
-                "sha256:d8e9187bfcd5ffedbe87403195e1fc340189a68463903c39e2b63307c9fa0394",
-                "sha256:eaeaa0888b7f3ccb7bcd40b50497ca30923dba14f385bde4af78fac713d6d6f6",
-                "sha256:f46af8d162f3d470d8ffc997aaf7a269996d205f9d746124a179d3abe05ac602",
-                "sha256:f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1",
-                "sha256:fe91be1c51c90e2afe6827601ca14353bbf3953f343c2129fa1e247d55fd95ba"
+                "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703",
+                "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf",
+                "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4",
+                "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85",
+                "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd",
+                "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae",
+                "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd",
+                "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca",
+                "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305",
+                "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409",
+                "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c",
+                "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb",
+                "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee",
+                "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a",
+                "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228",
+                "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897",
+                "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d",
+                "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f",
+                "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152",
+                "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf",
+                "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8",
+                "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11",
+                "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017",
+                "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929",
+                "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e",
+                "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"
             ],
             "index": "pypi",
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "mypy-extensions": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The approach to scaling a landing zone on AWS is [elaborated here](https://aws.a
 - `make destroy` destroys all cloud stacks with TF CDK.
 - `make clean` remove the cdktf.out folders for all clouds.
 
-Testing is split into four commands:
+Testing is split into several commands:
 
 - `make unittest` runs all the unit tests (i.e. tests that are not [marked as integration](https://docs.pytest.org/en/7.1.x/example/markers.html)).
 - `make integration-test` run all the integration tests.

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -28,6 +28,8 @@
 - `make aws-destroy-core` cdktf destroy core stack
 - `make aws-destroy-grafana` cdktf destroy grafana deashboard stack
 - `make aws-destroy-all` cdktf destroy all stacks
+- `make aws-test` aws specific tests
+- `make aws-e2e` aws specific end to end tests
 
 ## Grafana
 

--- a/infrastructure/gcp/README.md
+++ b/infrastructure/gcp/README.md
@@ -47,6 +47,8 @@ Subsequently, following components are built in stage `main_gcp_infra`:
 - `make gcp-destroy-core` cdktf destroy core stack
 - `make gcp-destroy-grafana` cdktf destroy grafana stack
 - `make gcp-destroy-all` cdktf destroy all stacks
+- `make gcp-test` gcp specific tests
+- `make gcp-e2e` gcp specific end to end tests
 
 ### Configure Grafana
 

--- a/infrastructure/gcp/cloudrun_component.py
+++ b/infrastructure/gcp/cloudrun_component.py
@@ -1,7 +1,10 @@
+import subprocess
+
 from cdktf_cdktf_provider_google import (cloud_run_service, project_iam_member,
                                          service_account)
 from constructs import Construct
 
+COMMIT = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("utf-8")
 
 class CloudRunComponent(Construct):
     def __init__(
@@ -22,11 +25,12 @@ class CloudRunComponent(Construct):
             location=location,
             project=project_id,
             metadata={"annotations": {"run.googleapis.com/ingress": "internal"}},
+            autogenerate_revision_name=True,
             template={
                 "spec": {
                     "containers": [
                         {
-                            "image": "australia-southeast1-docker.pkg.dev/contino-squad0-fc/flight-controller-event-receiver/event_receiver:latest",
+                            "image": f"australia-southeast1-docker.pkg.dev/contino-squad0-fc/flight-controller-event-receiver/event_receiver:{COMMIT}",
                             "ports": [{"container_port": 8080}],
                         },
                     ],

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,10 @@
 [pytest]
 env =
     DYNAMO_TABLE_NAME=event_sourcing_table
+    BIGQUERY_EVENTS_TABLE=contino-squad0-fc.event_sourcing_table.events_data
+    BIGQUERY_METRICs_TABLE=contino-squad0-fc.metric_sourcing_table.metrics_data
 pythonpath = code infa_aws_cdk
 markers =
     integration
+    aws
+    gcp

--- a/src/drivers/bigquery.py
+++ b/src/drivers/bigquery.py
@@ -1,6 +1,7 @@
-from datetime import datetime
 import json
-from typing import List, Optional
+import os
+from datetime import datetime
+from typing import List, Optional, Union
 from uuid import UUID, uuid4
 
 from google.cloud import bigquery
@@ -8,103 +9,94 @@ from google.cloud import bigquery
 from src.drivers.event_sink import EventSink
 from src.drivers.event_source import EventSource
 from src.drivers.metric_sink import MetricSink
-from src.entities.events import Event
+from src.entities.events import EVENT_CLASSES, Event
 from src.entities.metrics import Metric
-from src.entities.projects import (
-    ProjectCreated,
-    ProjectCreatedPayload,
-    ProjectRequested,
-    ProjectRequestedPayload,
-)
 
 
 class BigQueryMetricSink(MetricSink):
+    def __init__(self) -> None:
+        self.TABLE_NAME = os.environ.get("BIGQUERY_METRICS_TABLE")
+        self.client = bigquery.Client()
+
     def store_metrics(self, metrics: List[Metric]) -> Optional[Exception]:
-        if metrics:
-            client = bigquery.Client()
-            values = ""
+        try:
             for metric in metrics:
-                values += (
-                    f"('{metric.project_id}',{metric.lead_time},'{datetime.utcnow()}'),"
+                columns = f"aggregate_id, measure_name, time, measure_value"
+                if hasattr(metric, "dimensions"):
+                    for dimension in metric.dimensions.dimension_names:
+                        columns += f", {dimension}"
+                values = (
+                    f"'{metric.aggregate_id}','{metric.metric_type}','{datetime.utcnow()}', {metric.metric_value}"
                 )
-            values = values[:-1]
-            query = f"""
-        INSERT `flight_controller.project_lead_times`
-        VALUES {values}
-        """
+                if hasattr(metric, "dimensions"):
+                    for dimension in metric.dimensions.dimension_names:
+                        values += f", '{getattr(metric.dimensions, dimension)}'"
 
-            print(query)
+                query = f"""
+                INSERT `{self.TABLE_NAME}` ({columns})
+                VALUES ({values})
+                """
 
-            client.query(query).result()
-
-        return None
+                response = self.client.query(query).result()
+                self.client.close()
+            return None
+        except Exception as err:
+            return err
 
 
 class BigQueryEventSink(EventSink):
+    def __init__(self) -> None:
+        self.TABLE_NAME = os.environ.get("BIGQUERY_EVENTS_TABLE")
+        self.client = bigquery.Client()
+
     def store_events(self, events: List[Event]) -> Optional[Exception]:
-        client = bigquery.Client()
-        values = ""
-        for event in events:
-            values += f"('{event.event_id}','{event.event_type}','{event.aggregate_id}','{event.aggregate_type}',{event.aggregate_version},{event.event_version},SAFE.PARSE_JSON('{json.dumps(event.payload.__dict__)}'),'{datetime.utcnow()}'),"
-        values = values[:-1]
+        try:
+            values = ""
+            for event in events:
+                values += f"('{event.event_id}','{event.event_type}','{event.aggregate_id}','{event.aggregate_type}',{event.aggregate_version},{event.event_version},SAFE.PARSE_JSON('{json.dumps(event.payload.__dict__)}'),'{datetime.utcnow()}'),"
+            values = values[:-1]
 
-        query = f"""
-      INSERT `flight_controller.events`
-      VALUES {values}
-    """
-
-        print(query)
-
-        client.query(query).result()
-
-        return None
+            query = f"""
+            INSERT `{self.TABLE_NAME}`
+            VALUES {values}
+            """
+            response = self.client.query(query).result()
+            self.client.close()
+            return None
+        except Exception as err:
+            return err
 
 
 class BigQueryEventSource(EventSource):
-    def get_events_for_aggregate(self, aggregate_id: str) -> List[Event]:
-        client = bigquery.Client()
-        query = f"""
-        SELECT aggregate_id, aggregate_type, aggregate_version, event_id, event_version, payload, event_type
-        FROM `flight_controller.events`
-        WHERE aggregate_id = '{aggregate_id}'
-        ORDER BY aggregate_version ASC
-        """
+    def __init__(self) -> None:
+        self.TABLE_NAME = os.environ.get("BIGQUERY_EVENTS_TABLE")
+        self.client = bigquery.Client()
 
-        print(query)
+    def get_events_for_aggregate(self, aggregate_id: str) -> Union[Exception, List[Event]]:
+        try:
+            query = f"""
+            SELECT *
+            FROM `{self.TABLE_NAME}`
+            WHERE aggregate_id = '{aggregate_id}'
+            ORDER BY aggregate_version ASC
+            """
+            events: List[Event] = []
 
-        events: List[Event] = []
-
-        for row in client.query(query).result():
-            payload = json.loads(row[5])
-            if row[6] == "ProjectRequested":
-                events.append(
-                    ProjectRequested(
-                        row[0],
-                        row[1],
-                        row[2],
-                        UUID(row[3]),
-                        row[4],
-                        ProjectRequestedPayload(
-                            payload["aggregate_id"],
-                            payload["requested_time"],
-                        ),
-                        row[6],
+            for row in self.client.query(query).result():
+                event_type = row[1]
+                if event_type in EVENT_CLASSES:
+                    event_class, payload_class = EVENT_CLASSES[event_type]
+                    payload = payload_class(**json.loads(row[6]))
+                    event = event_class(
+                        aggregate_id=row[2],
+                        aggregate_type=row[3],
+                        aggregate_version=int(row[4]),
+                        event_id=UUID(row[0]),
+                        event_version=int(row[5]),
+                        payload=payload,
                     )
-                )
-            if row[6] == "ProjectCreated":
-                events.append(
-                    ProjectCreated(
-                        row[0],
-                        row[1],
-                        row[2],
-                        UUID(row[3]),
-                        row[4],
-                        ProjectCreatedPayload(
-                            payload["aggregate_id"],
-                            payload["created_time"],
-                        ),
-                        row[6],
-                    )
-                )
-
-        return events
+                    events.append(event)
+            self.client.close()
+            return events
+        except Exception as err:
+            return err

--- a/src/entities/events.py
+++ b/src/entities/events.py
@@ -45,6 +45,8 @@ Event = Union[
     PatchRunSummary,
     GuardrailPassed,
     GuardrailActivated,
+    IdentityCreated,
+    IdentityRequested
 ]
 
 Event_Type = Union[

--- a/src/entrypoints/aws_lambda.py
+++ b/src/entrypoints/aws_lambda.py
@@ -6,12 +6,9 @@ from src.drivers.timestream_metric_sink import TimeStreamMetricSink
 
 
 logger = structlog.get_logger(__name__)
-event_source = DynamoEventSource()
-event_sink = DynamoEventSink()
-metric_sink = TimeStreamMetricSink()
-
 
 def lambda_handler(event, _) -> None:
+    event_source, event_sink, metric_sink  = DynamoEventSource(), DynamoEventSink(), TimeStreamMetricSink()
     logger.msg("Incoming event", incoming_event=event)
     full_event = event["detail"]
     aggregate_events = event_source.get_events_for_aggregate(full_event["aggregate_id"])

--- a/src/entrypoints/cloudrun.py
+++ b/src/entrypoints/cloudrun.py
@@ -5,16 +5,12 @@ from typing import Any, Literal, Tuple, Union
 
 import structlog
 from flask import Flask, request
+
 from src.adapters.controller import handle_event
-from src.drivers.bigquery import (
-    BigQueryEventSink,
-    BigQueryEventSource,
-    BigQueryMetricSink,
-)
+from src.drivers.bigquery import (BigQueryEventSink, BigQueryEventSource,
+                                  BigQueryMetricSink)
 
 app = Flask(__name__)
-
-
 log = structlog.get_logger(__name__)
 
 

--- a/tests/features/accounts.feature
+++ b/tests/features/accounts.feature
@@ -1,6 +1,13 @@
 Feature: Capture useful metrics about accounts
 
-  Scenario: Stores account lead time
-    Given an account has been requested
-    When the account has been created
-    Then the account created lead time is stored correctly
+  @aws
+  Scenario: Stores account lead time for aws
+    Given an account has been requested for aws
+    When the account has been created for aws
+    Then the account created lead time is stored correctly for aws
+
+  @gcp
+  Scenario: Stores account lead time for gcp
+    Given an account has been requested for gcp
+    When the account has been created for gcp
+    Then the account created lead time is stored correctly for gcp

--- a/tests/features/compliance.feature
+++ b/tests/features/compliance.feature
@@ -1,6 +1,13 @@
 Feature: Capture useful metrics about resources
 
-  Scenario: Stores resource compliance lead time
-    Given a resource has been found non compliant
-    When the resource is found compliant
-    Then the compliance lead time is stored correctly
+  @aws
+  Scenario: Stores resource compliance lead time for aws
+    Given a resource has been found non compliant for aws
+    When the resource is found compliant for aws
+    Then the compliance lead time is stored correctly for aws
+
+  @gcp
+  Scenario: Stores resource compliance lead time for gcp
+    Given a resource has been found non compliant for gcp
+    When the resource is found compliant for gcp
+    Then the compliance lead time is stored correctly for gcp

--- a/tests/features/guardrail.feature
+++ b/tests/features/guardrail.feature
@@ -1,16 +1,36 @@
 Feature: Capture useful metrics around guardrail compliance
 
-  Scenario: Guardrail is activated and activation count is stored correctly.
-    When a guardrail has been activated
-    Then the activation count is stored correctly
+  @aws
+  Scenario: Guardrail is activated and activation count is stored correctly for aws
+    When a guardrail has been activated for aws
+    Then the activation count is stored correctly for aws
 
-  Scenario: Guardrail is activated and then passes. Store the lead time.
-    Given a guardrail has been activated
-    When a guardrail passes
-    Then the guardrail lead time is stored correctly
+  @aws
+  Scenario: Guardrail is activated and then passes. Store the lead time for aws
+    Given a guardrail has been activated for aws
+    When a guardrail passes for aws
+    Then the guardrail lead time is stored correctly for aws
 
-  Scenario: Guardrail is activated and then passes. Store the max activation count.
-    Given a guardrail has been activated
-    When a guardrail passes
-    Then the max activation count is stored correctly
+  @aws
+  Scenario: Guardrail is activated and then passes. Store the max activation count for aws
+    Given a guardrail has been activated for aws
+    When a guardrail passes for aws
+    Then the max activation count is stored correctly for aws
+
+  @gcp
+  Scenario: Guardrail is activated and activation count is stored correctly for gcp
+  When a guardrail has been activated for gcp
+  Then the activation count is stored correctly for gcp
+
+  @gcp
+  Scenario: Guardrail is activated and then passes. Store the lead time for gcp
+    Given a guardrail has been activated for gcp
+    When a guardrail passes for gcp
+    Then the guardrail lead time is stored correctly for gcp
+
+  @gcp
+  Scenario: Guardrail is activated and then passes. Store the max activation count for gcp
+    Given a guardrail has been activated for gcp
+    When a guardrail passes for gcp
+    Then the max activation count is stored correctly for gcp
 

--- a/tests/features/identity.feature
+++ b/tests/features/identity.feature
@@ -1,6 +1,13 @@
 Feature: Capture useful metrics about identity requests
 
-  Scenario: Stores lead time for identity
-    Given an identity has been requested
-    When the identity has been created
-    Then the identity created lead time is stored correctly
+  @aws
+  Scenario: Stores lead time for identity for aws
+    Given an identity has been requested for aws
+    When the identity has been created for aws
+    Then the identity created lead time is stored correctly for aws
+
+  @gcp
+  Scenario: Stores lead time for identity for gcp
+    Given an identity has been requested for gcp
+    When the identity has been created for gcp
+    Then the identity created lead time is stored correctly for gcp

--- a/tests/features/patch.feature
+++ b/tests/features/patch.feature
@@ -1,5 +1,11 @@
 Feature: Capture useful metrics about patching
 
-    Scenario: Stores metric around patching compliance percentage
-        When patch run summary is complete
-        Then the compliance percentage is stored correctly
+    @aws
+    Scenario: Stores metric around patching compliance percentage for aws
+        When patch run summary is complete for aws
+        Then the compliance percentage is stored correctly for aws
+
+    @gcp
+    Scenario: Stores metric around patching compliance percentage for gcp
+        When patch run summary is complete for gcp
+        Then the compliance percentage is stored correctly for gcp

--- a/tests/features/projects.feature
+++ b/tests/features/projects.feature
@@ -1,6 +1,13 @@
 Feature: Capture useful metrics about projects
 
-    Scenario: Stores project lead time
-        Given a project has been requested
-        When the project has been created
-        Then the lead time is stored correctly
+    @aws
+    Scenario: Stores project lead time for aws
+        Given a project has been requested for aws
+        When the project has been created for aws
+        Then the lead time is stored correctly for aws
+
+    @gcp
+    Scenario: Stores project lead time for gcp
+        Given a project has been requested for gcp
+        When the project has been created for gcp
+        Then the lead time is stored correctly for gcp

--- a/tests/features/steps/compliance_steps.py
+++ b/tests/features/steps/compliance_steps.py
@@ -1,68 +1,117 @@
-from time import sleep
-from behave import given, when, then
-from datetime import datetime
 import json
 import random
 import string
+from datetime import datetime
+from time import sleep
+
 import boto3
+from behave import given, then, when
+from google.cloud import bigquery, pubsub_v1
 
-event_bridge = boto3.client("events")
-time_stream = boto3.client("timestream-query")
 
-
-@given("a resource has been found non compliant")
-def found_non_compliant(context):
+@given("a resource has been found non compliant for {cloud}")
+def found_non_compliant(context, cloud):
     context.aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
     requested_time = int(round(datetime.utcnow().timestamp()))
 
-    response = event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test project request Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "resource_found_non_compliant",
-                        "container_id": "123456789012",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+    if cloud == "aws":
+        context.event_bridge = boto3.client("events")
+        context.time_stream = boto3.client("timestream-query")
 
-    assert response["FailedEntryCount"] == 0
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test project request Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "resource_found_non_compliant",
+                            "container_id": "123456789012",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
 
+    elif cloud == "gcp":
+        context.bigquery_client = bigquery.Client()
+        context.publisher = pubsub_v1.PublisherClient()
+        context.topic_path = context.publisher.topic_path(project="contino-squad0-fc", topic="flight-controller")
 
-@when("the resource is found compliant")
-def found_compliant(context):
-    sleep(3)
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "resource_found_non_compliant",
+                    "container_id": "123456789012",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
+
+@when("the resource is found compliant for {cloud}")
+def found_compliant(context, cloud):
+    sleep(5)
     requested_time = int(round(datetime.utcnow().timestamp()))
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test project create Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "resource_found_compliant",
-                        "container_id": "123456789012",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+
+    if cloud == "aws":
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test project create Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "resource_found_compliant",
+                            "container_id": "123456789012",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
+        
+    elif cloud == "gcp":
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "resource_found_compliant",
+                    "container_id": "123456789012",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@then("the compliance lead time is stored correctly")
-def lead_time_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'resource_compliance_lead_time'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the compliance lead time is stored correctly for {cloud}")
+def lead_time_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'resource_compliance_lead_time'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'resource_compliance_lead_time'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1

--- a/tests/features/steps/guardrail_steps.py
+++ b/tests/features/steps/guardrail_steps.py
@@ -1,93 +1,176 @@
-from time import sleep
-from behave import given, then, when
-from datetime import datetime
 import json
 import random
 import string
+from datetime import datetime
+from time import sleep
+
 import boto3
+from behave import given, then, when
+from google.cloud import bigquery, pubsub_v1
 
-event_bridge = boto3.client("events")
-time_stream = boto3.client("timestream-query")
 
-
-def guardrail_activated(context):
+def guardrail_activated(context, cloud):
     context.aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
     context.guardrail_id = "".join(random.choices(string.ascii_letters, k=12))
     requested_time = int(round(datetime.utcnow().timestamp()))
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test guardrail activated event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "guardrail_activated",
-                        "guardrail_id": f"{context.guardrail_id}",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+
+    if cloud == "aws":
+        context.event_bridge = boto3.client("events")
+        context.time_stream = boto3.client("timestream-query")
+
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test guardrail activated event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "guardrail_activated",
+                            "guardrail_id": f"{context.guardrail_id}",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
+
+    elif cloud == "gcp":
+        context.bigquery_client = bigquery.Client()
+        context.publisher = pubsub_v1.PublisherClient()
+        context.topic_path = context.publisher.topic_path(project="contino-squad0-fc", topic="flight-controller")
+
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "guardrail_activated",
+                    "guardrail_id": f"{context.guardrail_id}",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@given("a guardrail has been activated")
-def given_guardrail_activated(context):
-    guardrail_activated(context)
+@given("a guardrail has been activated for {cloud}")
+def given_guardrail_activated(context, cloud):
+    guardrail_activated(context, cloud)
 
 
-@when("a guardrail has been activated")
-def when_guardrail_activated(context):
-    guardrail_activated(context)
+@when("a guardrail has been activated for {cloud}")
+def when_guardrail_activated(context, cloud):
+    guardrail_activated(context, cloud)
 
 
-@when("a guardrail passes")
-def guardrail_passes(context):
-    sleep(3)
+@when("a guardrail passes for {cloud}")
+def guardrail_passes(context, cloud):
+    sleep(5)
     requested_time = int(round(datetime.utcnow().timestamp()))
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test guardrail passed event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "guardrail_passed",
-                        "guardrail_id": f"{context.guardrail_id}",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+
+    if cloud == "aws":
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test guardrail passed event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "guardrail_passed",
+                            "guardrail_id": f"{context.guardrail_id}",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
+
+    elif cloud == "gcp":
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "guardrail_passed",
+                    "guardrail_id": f"{context.guardrail_id}",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@then("the activation count is stored correctly")
-def metric_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_activation_count'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the activation count is stored correctly for {cloud}")
+def metric_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_activation_count'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'guardrail_activation_count'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1
 
 
-@then("the guardrail lead time is stored correctly")
-def metric_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_lead_time'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the guardrail lead time is stored correctly for {cloud}")
+def metric_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_lead_time'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'guardrail_lead_time'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1
 
 
-@then("the max activation count is stored correctly")
-def metric_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_max_activation'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the max activation count is stored correctly for {cloud}")
+def metric_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'guardrail_max_activation'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'guardrail_max_activation'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1

--- a/tests/features/steps/identity_steps.py
+++ b/tests/features/steps/identity_steps.py
@@ -1,69 +1,120 @@
-from time import sleep
-from behave import given, when, then
-from datetime import datetime
 import json
 import random
 import string
+from datetime import datetime
+from time import sleep
+
 import boto3
+from behave import given, then, when
+from google.cloud import bigquery, pubsub_v1
 
-eventBridge = boto3.client("events")
-timeStream = boto3.client("timestream-query")
 
-
-@given("an identity has been requested")
-def request_identity(context):
+@given("an identity has been requested for {cloud}")
+def request_identity(context, cloud):
     context.aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
     context.account_id = "".join(random.choices(string.ascii_letters, k=12))
     requested_time = int(round(datetime.utcnow().timestamp()))
 
-    response = eventBridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test identity request Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "identity_requested",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                        "account_id": f"{context.account_id}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+    if cloud == "aws":
+        context.event_bridge = boto3.client("events")
+        context.time_stream = boto3.client("timestream-query")
 
-    assert response["FailedEntryCount"] == 0
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test identity request Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "identity_requested",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                            "account_id": f"{context.account_id}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+
+        assert response["FailedEntryCount"] == 0
+
+    elif cloud == "gcp":
+        context.bigquery_client = bigquery.Client()
+        context.publisher = pubsub_v1.PublisherClient()
+        context.topic_path = context.publisher.topic_path(project="contino-squad0-fc", topic="flight-controller")
+
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "identity_requested",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                    "account_id": f"{context.account_id}",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@when("the identity has been created")
-def created_identity(context):
-    sleep(3)
+@when("the identity has been created for {cloud}")
+def created_identity(context, cloud):
+    sleep(5)
     requested_time = int(round(datetime.utcnow().timestamp()))
-    eventBridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test identity create Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "identity_created",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                        "account_id": f"{context.account_id}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+
+    if cloud == "aws":
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test identity create Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "identity_created",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                            "account_id": f"{context.account_id}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
+
+    elif cloud == "gcp":
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "identity_created",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                    "account_id": f"{context.account_id}",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@then("the identity created lead time is stored correctly")
-def lead_time_stored(context):
-    sleep(2)
-    result = timeStream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'identity_lead_time'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the identity created lead time is stored correctly for {cloud}")
+def lead_time_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'identity_lead_time'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'identity_lead_time'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1

--- a/tests/features/steps/patch_steps.py
+++ b/tests/features/steps/patch_steps.py
@@ -1,44 +1,80 @@
-from time import sleep
-from behave import when, then
-from datetime import datetime
 import json
 import random
 import string
+from datetime import datetime
+from time import sleep
+
 import boto3
+from behave import then, when
+from google.cloud import bigquery, pubsub_v1
 
-event_bridge = boto3.client("events")
-time_stream = boto3.client("timestream-query")
 
-
-@when("patch run summary is complete")
-def received_summary(context):
-    sleep(3)
+@when("patch run summary is complete for {cloud}")
+def received_summary(context, cloud):
     context.aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
     requested_time = int(round(datetime.utcnow().timestamp()))
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test Patch Summary Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "patch_run_summary",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                        "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
-                        "successful_instances": "i-peoritdsfl",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+
+    if cloud == "aws":
+        context.event_bridge = boto3.client("events")
+        context.time_stream = boto3.client("timestream-query")
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test Patch Summary Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "patch_run_summary",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                            "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
+                            "successful_instances": "i-peoritdsfl",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
+
+    elif cloud == "gcp":
+        context.bigquery_client = bigquery.Client()
+        context.publisher = pubsub_v1.PublisherClient()
+        context.topic_path = context.publisher.topic_path(project="contino-squad0-fc", topic="flight-controller")
+
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "patch_run_summary",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                    "failed_instances": "i-adslkjfds,i-89dsfkjdkfj",
+                    "successful_instances": "i-peoritdsfl",
+                }
+            ).encode("utf-8"),
+        ).result()
 
 
-@then("the compliance percentage is stored correctly")
-def compliance_percentage_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'patch_compliance_percentage'"
-    )
-    assert len(result["Rows"]) == 1
+@then("the compliance percentage is stored correctly for {cloud}")
+def compliance_percentage_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'patch_compliance_percentage'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'patch_compliance_percentage'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1

--- a/tests/features/steps/project_steps.py
+++ b/tests/features/steps/project_steps.py
@@ -1,65 +1,112 @@
-from time import sleep
-from behave import given, when, then
-from datetime import datetime
 import json
 import random
 import string
+from datetime import datetime
+from time import sleep
+
 import boto3
-
-event_bridge = boto3.client("events")
-time_stream = boto3.client("timestream-query")
-aggregate_id = "behaveTest"
+from behave import given, then, when
+from google.cloud import bigquery, pubsub_v1
 
 
-@given("a project has been requested")
-def request_project(context):
+
+@given("a project has been requested for {cloud}")
+def request_project(context, cloud):
     context.aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
     requested_time = int(round(datetime.utcnow().timestamp()))
 
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test project request Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "project_requested",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
+    if cloud == "aws":
+        context.event_bridge = boto3.client("events")
+        context.time_stream = boto3.client("timestream-query")
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test project request Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "project_requested",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
 
+    elif cloud == "gcp":
+        context.bigquery_client = bigquery.Client()
+        context.publisher = pubsub_v1.PublisherClient()
+        context.topic_path = context.publisher.topic_path(project="contino-squad0-fc", topic="flight-controller")
 
-@when("the project has been created")
-def create_project(context):
-    sleep(3)
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "project_requested",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
+
+@when("the project has been created for {cloud}")
+def create_project(context, cloud):
+    sleep(5)
     requested_time = int(round(datetime.utcnow().timestamp()))
-    event_bridge.put_events(
-        Entries=[
-            {
-                "Source": "contino.custom",
-                "DetailType": "Test project create Event",
-                "Detail": json.dumps(
-                    {
-                        "event_type": "project_created",
-                        "aggregate_id": f"{context.aggregate_id}",
-                        "timestamp": f"{requested_time}",
-                    }
-                ),
-                "EventBusName": "main_lambda_bus_cdktf",
-            }
-        ]
-    )
 
+    if cloud == "aws":
+        response = context.event_bridge.put_events(
+            Entries=[
+                {
+                    "Source": "contino.custom",
+                    "DetailType": "Test project create Event",
+                    "Detail": json.dumps(
+                        {
+                            "event_type": "project_created",
+                            "aggregate_id": f"{context.aggregate_id}",
+                            "timestamp": f"{requested_time}",
+                        }
+                    ),
+                    "EventBusName": "main_lambda_bus_cdktf",
+                }
+            ]
+        )
+        assert response["FailedEntryCount"] == 0
 
-@then("the lead time is stored correctly")
-def lead_time_stored(context):
-    sleep(2)
-    result = time_stream.query(
-        QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'project_lead_time'"
-    )
-    assert len(result["Rows"]) == 1
+    elif cloud == "gcp":
+        context.publisher.publish(
+            context.topic_path,
+            json.dumps(
+                {
+                    "event_type": "project_created",
+                    "aggregate_id": f"{context.aggregate_id}",
+                    "timestamp": f"{requested_time}",
+                }
+            ).encode("utf-8"),
+        ).result()
+
+@then("the lead time is stored correctly for {cloud}")
+def lead_time_stored(context, cloud):
+    sleep(10)
+
+    if cloud == "aws":
+        result = context.time_stream.query(
+            QueryString=f"select * from core_timestream_db.metrics_table where aggregate_id = '{context.aggregate_id}' and measure_name = 'project_lead_time'"
+        )
+        assert len(result["Rows"]) == 1
+
+    elif cloud == "gcp":
+        query = f"""
+        SELECT *
+        FROM `contino-squad0-fc.metric_sourcing_table.metrics_data`
+        WHERE aggregate_id = '{context.aggregate_id}' AND measure_name = 'project_lead_time'
+        """
+        got = context.bigquery_client.query(query).result()
+        rows = []
+        for row in got:
+            rows.append(row)
+        context.bigquery_client.close()
+        assert len(rows) >= 1

--- a/tests/publisher/drivers/test_event_bridge.py
+++ b/tests/publisher/drivers/test_event_bridge.py
@@ -9,7 +9,7 @@ from publisher.entities.events import (
     GuardrailPassed,
 )
 
-EVENT_SINK = EventBridge()
+
 AGGREGATE_ID = str(uuid4())
 ALTERNATE_ID = str(uuid4())
 CURRENT_TIME = int(time())
@@ -36,21 +36,29 @@ DOZEN_EVENTS = [
 ]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_event_bridge_returns_response():
-    assert isinstance(EVENT_SINK.send_events(EVENTS), str)
+    event_sink = EventBridge()
+    assert isinstance(event_sink.send_events(EVENTS), str)
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_event_bridge_returns_no_exception():
-    assert not isinstance(EVENT_SINK.send_events(EVENTS), Exception)
+    event_sink = EventBridge()
+    assert not isinstance(event_sink.send_events(EVENTS), Exception)
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_event_bridge_handles_more_then_10_events():
-    assert not isinstance(EVENT_SINK.send_events(DOZEN_EVENTS), Exception)
+    event_sink = EventBridge()
+    assert not isinstance(event_sink.send_events(DOZEN_EVENTS), Exception)
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_event_bridge_returns_exception_on_no_events():
-    assert isinstance(EVENT_SINK.send_events([]), Exception)
+    event_sink = EventBridge()
+    assert isinstance(event_sink.send_events([]), Exception)

--- a/tests/publisher/entrypoints/test_main.py
+++ b/tests/publisher/entrypoints/test_main.py
@@ -9,7 +9,7 @@ from publisher.drivers.source import OpenPolicyAgent
 
 ARGS = argparse.Namespace()
 
-
+@pytest.mark.aws
 @pytest.mark.integration
 def test_main_returns_no_exception():
     ARGS.source = "open_policy_agent"
@@ -79,7 +79,8 @@ def test_main_returns_exception_when_source_returns_exception(mock_get_events):
     mock_get_events.return_value = Exception()
     assert isinstance(main(ARGS), Exception)
 
-
+@pytest.mark.aws
+@pytest.mark.integration
 @patch.object(EventBridge, "send_events")
 def test_main_returns_exception_when_sink_returns_exception(mock_send_events):
     ARGS.source = "open_policy_agent"

--- a/tests/src/drivers/test_bigquery.py
+++ b/tests/src/drivers/test_bigquery.py
@@ -1,0 +1,436 @@
+from datetime import datetime
+import os
+import random
+import string
+from uuid import uuid4
+
+import pytest
+
+from src.drivers.bigquery import BigQueryEventSink, BigQueryEventSource, BigQueryMetricSink
+
+from src.entities.accounts import (
+    AccountCreated,
+    AccountCreatedPayload,
+    AccountRequested,
+    AccountRequestedPayload,
+    AccountLeadTime
+)
+from src.entities.compliance import (
+    ResourceFoundCompliant,
+    ResourceFoundCompliantPayload,
+    ResourceFoundNonCompliant,
+    ResourceFoundNonCompliantPayload,
+    ResourceComplianceExtraDimensions,
+    ResourceComplianceLeadTime,
+)
+from src.entities.guardrail import (
+    GuardrailActivated,
+    GuardrailActivatedPayload,
+    GuardrailPassed,
+    GuardrailPassedPayload,
+    GuardrailActivationCount,
+    GuardrailExtraDimensions,
+    GuardrailLeadTime,
+    GuardrailMaxActivation,
+)
+from src.entities.identity import (
+    IdentityCreated,
+    IdentityCreatedPayload,
+    IdentityRequested,
+    IdentityRequestedPayload,
+    IdentityLeadTime
+)
+from src.entities.patch import (
+    PatchRunSummary,
+    PatchRunSummaryPayload,
+    PatchCompliancePercentage
+)
+from src.entities.projects import (
+    ProjectCreated,
+    ProjectCreatedPayload,
+    ProjectRequested,
+    ProjectRequestedPayload,
+    ProjectLeadTime
+)
+
+@pytest.fixture(autouse=True)
+def set_table_name():
+    os.environ["BIGQUERY_EVENTS_TABLE"] = "contino-squad0-fc.event_sourcing_table.events_data"
+    os.environ["BIGQUERY_METRICS_TABLE"] = "contino-squad0-fc.metric_sourcing_table.metrics_data"
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_returns_error_on_non_existent_table():
+    os.environ["BIGQUERY_EVENTS_TABLE"] = "does_not_exist"
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = ProjectRequested(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=ProjectRequestedPayload(
+            timestamp=int(round(datetime.utcnow().timestamp()))
+        ),
+    )
+    sink = BigQueryEventSink()
+
+    assert isinstance(sink.store_events([event]), Exception)
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_project_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = ProjectRequested(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=ProjectRequestedPayload(
+            timestamp=int(round(datetime.utcnow().timestamp()))
+        ),
+    )
+
+    event_2 = ProjectCreated(
+        aggregate_id=aggregate_id,
+        aggregate_version=2,
+        event_id=uuid4(),
+        payload=ProjectCreatedPayload(
+            timestamp=int(round(datetime.utcnow().timestamp()))
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event, event_2])
+
+    source =  BigQueryEventSource()
+    
+    got =  source.get_events_for_aggregate(event.aggregate_id)
+
+    assert got == [event, event_2]
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_compliance_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    container_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = ResourceFoundCompliant(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=ResourceFoundCompliantPayload(
+            container_id=container_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    event_2 = ResourceFoundNonCompliant(
+        aggregate_id=aggregate_id,
+        aggregate_version=2,
+        event_id=uuid4(),
+        payload=ResourceFoundNonCompliantPayload(
+            container_id=container_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event, event_2])
+
+    source = BigQueryEventSource()
+
+    got = source.get_events_for_aggregate(aggregate_id)
+
+    assert got == [event, event_2]
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_patch_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = PatchRunSummary(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=PatchRunSummaryPayload(
+            timestamp=int(round(datetime.utcnow().timestamp())),
+            successful_instances="i-adslkjfds,i-89dsfkjdkfj",
+            failed_instances="i-peoritdsfl",
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event])
+
+    source = BigQueryEventSource()
+
+    got = source.get_events_for_aggregate(aggregate_id)
+
+    assert got == [event]
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_account_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = AccountRequested(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=AccountRequestedPayload(
+            timestamp=int(round(datetime.utcnow().timestamp()))
+        ),
+    )
+    event_2 = AccountCreated(
+        aggregate_id=aggregate_id,
+        aggregate_version=2,
+        event_id=uuid4(),
+        payload=AccountCreatedPayload(
+            timestamp=int(round(datetime.utcnow().timestamp()))
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event, event_2])
+
+    source = BigQueryEventSource()
+
+    got = source.get_events_for_aggregate(aggregate_id)
+
+    assert got == [event, event_2]
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_guardrail_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    guardrail_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = GuardrailPassed(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=GuardrailPassedPayload(
+            guardrail_id=guardrail_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    event_2 = GuardrailActivated(
+        aggregate_id=aggregate_id,
+        aggregate_version=2,
+        event_id=uuid4(),
+        payload=GuardrailActivatedPayload(
+            guardrail_id=guardrail_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event, event_2])
+
+    source = BigQueryEventSource()
+
+    got = source.get_events_for_aggregate(aggregate_id)
+
+    assert got == [event, event_2]
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_retrieves_identity_events_from_dynamodb():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    event = IdentityRequested(
+        aggregate_id=aggregate_id,
+        aggregate_version=1,
+        event_id=uuid4(),
+        payload=IdentityRequestedPayload(
+            account_id=aggregate_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    event_2 = IdentityCreated(
+        aggregate_id=aggregate_id,
+        aggregate_version=2,
+        event_id=uuid4(),
+        payload=IdentityCreatedPayload(
+            account_id=aggregate_id,
+            timestamp=int(round(datetime.utcnow().timestamp())),
+        ),
+    )
+    sink = BigQueryEventSink()
+    sink.store_events([event, event_2])
+
+    source = BigQueryEventSource()
+
+    got = source.get_events_for_aggregate(aggregate_id)
+
+    assert got == [event, event_2]
+
+
+# Big Query Store metrics Tests
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_returns_error_on_non_existent_database():
+    os.environ["BIGQUERY_METRICS_TABLE"] = "does_not_exist"
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert isinstance(
+        sink.store_metrics(
+            [
+                ProjectLeadTime(aggregate_id=aggregate_id, metric_value=lead_time),
+            ]
+        ),
+        Exception,
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_metrics_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                ProjectLeadTime(aggregate_id=aggregate_id, metric_value=lead_time),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_resource_compliance_lead_time_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    container_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                ResourceComplianceLeadTime(
+                    aggregate_id=aggregate_id,
+                    metric_value=lead_time,
+                    dimensions=ResourceComplianceExtraDimensions(
+                        dimension_names=["container_id"], container_id=container_id
+                    ),
+                ),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_patch_compliance_percentage_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    patch_percentage = random.randint(0, 100)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                PatchCompliancePercentage(
+                    aggregate_id=aggregate_id, metric_value=patch_percentage
+                ),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_resource_account_lead_time_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                AccountLeadTime(aggregate_id=aggregate_id, metric_value=lead_time),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_guardrail_activation_count_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    guardrail_id = "".join(random.choices(string.ascii_letters, k=12))
+    count = random.randint(0, 100)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                GuardrailActivationCount(
+                    aggregate_id=aggregate_id,
+                    metric_value=count,
+                    dimensions=GuardrailExtraDimensions(
+                        dimension_names=["guardrail_id"], guardrail_id=guardrail_id
+                    ),
+                ),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_guardrail_max_activation_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    guardrail_id = "".join(random.choices(string.ascii_letters, k=12))
+    count = random.randint(0, 100)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                GuardrailMaxActivation(
+                    aggregate_id=aggregate_id,
+                    metric_value=count,
+                    dimensions=GuardrailExtraDimensions(
+                        dimension_names=["guardrail_id"], guardrail_id=guardrail_id
+                    ),
+                ),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_guardrail_lead_time_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    guardrail_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                GuardrailLeadTime(
+                    aggregate_id=aggregate_id,
+                    metric_value=lead_time,
+                    dimensions=GuardrailExtraDimensions(
+                        dimension_names=["guardrail_id"], guardrail_id=guardrail_id
+                    ),
+                ),
+            ]
+        )
+        is None
+    )
+
+
+@pytest.mark.gcp
+@pytest.mark.integration
+def test_store_identity_lead_time_does_not_return_error():
+    aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
+    lead_time = random.randint(0, 7200)
+    sink = BigQueryMetricSink()
+    assert (
+        sink.store_metrics(
+            [
+                IdentityLeadTime(aggregate_id=aggregate_id, metric_value=lead_time),
+            ]
+        )
+        is None
+    )

--- a/tests/src/drivers/test_dynamo_event_sink.py
+++ b/tests/src/drivers/test_dynamo_event_sink.py
@@ -48,6 +48,7 @@ def set_table_name():
     os.environ["DYNAMO_TABLE_NAME"] = "event_sourcing_table"
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_returns_error_on_non_existent_table():
     os.environ["DYNAMO_TABLE_NAME"] = "does_not_exist"
@@ -65,6 +66,7 @@ def test_returns_error_on_non_existent_table():
     assert isinstance(sink.store_events([event]), Exception)
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_project_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -94,6 +96,7 @@ def test_retrieves_project_events_from_dynamodb():
     assert got == [event, event_2]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_compliance_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -126,6 +129,7 @@ def test_retrieves_compliance_events_from_dynamodb():
     assert got == [event, event_2]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_patch_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -149,6 +153,7 @@ def test_retrieves_patch_events_from_dynamodb():
     assert got == [event]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_account_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -178,6 +183,7 @@ def test_retrieves_account_events_from_dynamodb():
     assert got == [event, event_2]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_guardrail_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -210,6 +216,7 @@ def test_retrieves_guardrail_events_from_dynamodb():
     assert got == [event, event_2]
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_retrieves_identity_events_from_dynamodb():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))

--- a/tests/src/drivers/test_timestream_metric_sink.py
+++ b/tests/src/drivers/test_timestream_metric_sink.py
@@ -27,6 +27,7 @@ def set_env_vars():
     os.environ["TIMESTREAM_TABLE_NAME"] = "metrics_table"
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_returns_error_on_non_existent_database():
     os.environ["TIMESTREAM_DATABASE_NAME"] = "does_not_exist"
@@ -43,6 +44,7 @@ def test_returns_error_on_non_existent_database():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_metrics_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -58,6 +60,7 @@ def test_store_metrics_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_resource_compliance_lead_time_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -80,6 +83,7 @@ def test_store_resource_compliance_lead_time_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_patch_compliance_percentage_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -97,6 +101,7 @@ def test_store_patch_compliance_percentage_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_resource_account_lead_time_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -112,6 +117,7 @@ def test_store_resource_account_lead_time_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_guardrail_activation_count_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -134,6 +140,7 @@ def test_store_guardrail_activation_count_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_guardrail_max_activation_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -156,6 +163,7 @@ def test_store_guardrail_max_activation_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_guardrail_lead_time_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
@@ -178,6 +186,7 @@ def test_store_guardrail_lead_time_does_not_return_error():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_store_identity_lead_time_does_not_return_error():
     aggregate_id = "".join(random.choices(string.ascii_letters, k=12))

--- a/tests/src/entrypoints/test_lamdarun.py
+++ b/tests/src/entrypoints/test_lamdarun.py
@@ -1,16 +1,17 @@
-from datetime import datetime
 import os
 import random
 import string
+from datetime import datetime
 
 import pytest
-from src.entrypoints.aws_lambda import lambda_handler
 
+from src.entrypoints.aws_lambda import lambda_handler
 
 aggregate_id = "".join(random.choices(string.ascii_letters, k=12))
 requested_time = int(round(datetime.utcnow().timestamp()))
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_lambda_handles_basic_event():
     lambda_handler(
@@ -25,6 +26,7 @@ def test_lambda_handles_basic_event():
     )
 
 
+@pytest.mark.aws
 @pytest.mark.integration
 def test_lambda_handles_unknown_event_type():
     lambda_handler(


### PR DESCRIPTION
- Fix the bigquery driver and update the event sink and source, aswell as the metric sink.
- Update driver tests to work with the updated drivers
- Update the docker file to use table name environment variables.
- Update pytest with table name environment variables
- Create a unit test workflow that runs before cloud workflows, reducing redundant testing.
- Add tagging within pytest to allow running integrations tests for each cloud.
- Update behave test to have tagging and test arguments for each cloud.